### PR TITLE
replace encoding/binary.bigEndian.Uint32(...), avoid some panic in so…

### DIFF
--- a/converters/type_conversion.go
+++ b/converters/type_conversion.go
@@ -2,7 +2,6 @@ package converters
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"math"
 	"time"
@@ -146,7 +145,19 @@ func DecodeDate(data []byte) (time.Time, error) {
 	year += int(data[1]) - 100
 	nanoSec := 0
 	if len(data) > 7 {
-		nanoSec = int(binary.BigEndian.Uint32(data[7:10]))
+		dateTmp := data[7:10]
+		switch len(dateTmp) {
+		case 0:
+			nanoSec = 0
+		case 1:
+			nanoSec = int(uint32(dateTmp[0]))
+		case 2:
+			nanoSec = int(uint32(dateTmp[0]) | uint32(dateTmp[1])<<8)
+		case 3:
+			nanoSec = int(uint32(dateTmp[0]) | uint32(dateTmp[1])<<8 | uint32(dateTmp[2])<<16)
+		default:
+			nanoSec = int(uint32(dateTmp[0]) | uint32(dateTmp[1])<<8 | uint32(dateTmp[2])<<16 | uint32(dateTmp[3])<<24)
+		}
 	}
 	tzHour := 0
 	tzMin := 0


### PR DESCRIPTION
…me case.

I don't know if it's go library's miss.
`_ = b[3] `
for bound check.

https://github.com/golang/go/blob/e463c28cc116fb1f40a4e203bddf93b6ef52c8d9/src/encoding/binary/binary.go#L111

But in date conversion, when len(data) > 7, pass to binary.BigEndian.Uint32 is data[7:10]).
https://github.com/sijms/go-ora/blob/5534877cf72d47da17845457d4eabf7a936c4c6a/converters/type_conversion.go#L149

I got the panic: 
panic: runtime error: index out of range [3] with length 3

go version go1.15.3 windows/amd64