### PR TITLE
Fix user rejected when user's name contains brackets ()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -6,12 +6,13 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/converters"
-	"github.com/sijms/go-ora/network"
 	"os"
 	"os/user"
 	"strconv"
 	"strings"
+
+	"github.com/sijms/go-ora/converters"
+	"github.com/sijms/go-ora/network"
 )
 
 type ConnectionState int
@@ -304,7 +305,7 @@ func NewConnection(databaseUrl string) (*Connection, error) {
 	userName := ""
 	User, err := user.Current()
 	if err == nil {
-		userName = User.Name
+		userName = User.Username
 	}
 	hostName, _ := os.Hostname()
 	indexOfSlash := strings.LastIndex(os.Args[0], "/")


### PR DESCRIPTION
I have found the root reason of rejected  connection when my VPN is up.
To do that, I have added trace capability for dumping exchanged packets. I have looked at data exchanged, and noticed that connection string was different whenever I'm connected to the VPN.

So, When the VPN is up, my user is the domain user: `Cassan Jean-Francois (EXTERNAL)`.
When the VPN is down, my user is the local machine user, `jf.cassan` 

And apparently having brackets in user name is not supported. The server refuses the connection without motive, leading to the panic (see  #26).

So I have changed the function `NewConnection` for using UserName instead of  Name.

I'll open another PR for packet dump.
