### PR TITLE
Fix #40 rows.Next() skips first records

### DIFF
--- a/command.go
+++ b/command.go
@@ -409,6 +409,7 @@ func (stmt *Stmt) read(dataSet *DataSet) error {
 	containOutputPars := false
 	dataSet.parent = stmt
 	session := stmt.connection.session
+	dataSet.index = 0
 	for loop {
 		msg, err := session.GetByte()
 		if err != nil {


### PR DESCRIPTION
Fix and simplify (DataSet) Next function

I suggest you to test it before merging. The solution looks to simple for been error less. 

