### PR TITLE
Resolved minor spelling mistake in error message.

### DIFF
--- a/v2/network/oracle_error.go
+++ b/v2/network/oracle_error.go
@@ -15,7 +15,7 @@ func (err *OracleError) translate() {
 		err.ErrMsg = "ORA-12564: TNS connection refused"
 		return
 	case 12514:
-		err.ErrMsg = "ORA-12514: TNS:listener does nto currently know of service requested in connect descriptor"
+		err.ErrMsg = "ORA-12514: TNS:listener does not currently know of service requested in connect descriptor"
 		return
 	default:
 		err.ErrMsg = ""


### PR DESCRIPTION
I encountered this mistake while using the library, just a small spelling mistake fix.