### PR TITLE
PathEscape to encode " " as "%20" instead of "+" (for password)

### DIFF
--- a/v2/connection_string.go
+++ b/v2/connection_string.go
@@ -112,8 +112,8 @@ type ConnectionString struct {
 // this function help build a will formed databaseURL and accept any character as it
 // convert special charters to corresponding values in URL
 func BuildUrl(server string, port int, service, user, password string, options map[string]string) string {
-	ret := fmt.Sprintf("oracle://%s:%s@%s/%s", url.QueryEscape(user), url.QueryEscape(password),
-		net.JoinHostPort(server, strconv.Itoa(port)), url.QueryEscape(service))
+	ret := fmt.Sprintf("oracle://%s:%s@%s/%s", url.PathEscape(user), url.PathEscape(password),
+		net.JoinHostPort(server, strconv.Itoa(port)), url.PathEscape(service))
 	if options != nil {
 		ret += "?"
 		for key, val := range options {


### PR DESCRIPTION
or else password with SPACE doesn't work
___
scheme:[//[user:password@]host[:port]]path[?query][#fragment]
before "?" is Path
after "?" is Query
https://www.callicoder.com/golang-url-encoding-decoding/#:~:text=URL%20Encoding%20or%20Escaping%20a%20String%20in%20Go&text=Go%20provides%20the%20following%20two,inside%20a%20URL%20path%20segment.

(but it doesn't matter, because what matters is how oracle implemented it..)