### PR TITLE
Forgot put `Valid = true` for the custom type `NullTimeStamp` Scan

### DIFF
--- a/v2/custom_types.go
+++ b/v2/custom_types.go
@@ -116,6 +116,7 @@ func (val *NullTimeStamp) Scan(value interface{}) error {
 		val.Valid = false
 		return nil
 	}
+	val.Valid = true
 	return val.TimeStamp.Scan(value)
 }
 


### PR DESCRIPTION
To reproduce the solution we need to start with a `Valid = true`

```go
//bad
var expire go_ora.NullTimeStamp
err := db.QueryRow("SELECT SYSTIMESTAMP FROM DUAL").Scan(&expire)
expire_time, err := expire.Value()
log.Info(expire_time)
//  <nil> 

//good!
expire := go_ora.NullTimeStamp{Valid: true}
err := db.QueryRow("SELECT SYSTIMESTAMP FROM DUAL").Scan(&expire)
expire_time, err := expire.Value()
log.Info(expire_time)
// 2022-07-03 07:14:44.351827 +6400 +6400 
```