### PR TITLE
Fixed https://github.com/sijms/go-ora/issues/213

### DIFF
--- a/network/session.go
+++ b/network/session.go
@@ -269,7 +269,8 @@ func (session *Session) negotiate() {
 // then send connect packet to the server and
 // receive either accept, redirect or refuse packet
 func (session *Session) Connect(ctx context.Context) error {
-	session.ctx = ctx
+	session.StartContext(ctx)
+	defer session.EndContext()
 	connOption := session.Context.ConnOption
 	session.Disconnect()
 	connOption.Tracer.Print("Connect")


### PR DESCRIPTION
When using QueryRow or QueryRowContext the context is permanently attached to a new Connection, because Connect is called with the same Context. According to the documentation the Context in Connect should only be used while connecting to the database, not for subsequent queries.