### PR TITLE
NewStmt: ignore all leading comment blocks

### DIFF
--- a/v2/command.go
+++ b/v2/command.go
@@ -256,14 +256,21 @@ func NewStmt(text string, conn *Connection) *Stmt {
 	ret.arrayBindCount = 0
 	ret.scnForSnapshot = make([]int, 2)
 	// get stmt type
-	uCmdText := strings.TrimSpace(strings.ToUpper(text))
+	uCmdText := strings.ToUpper(text)
 	for {
+		uCmdText = strings.TrimSpace(uCmdText) // trim leading white-space
 		if strings.HasPrefix(uCmdText, "--") {
 			i := strings.Index(uCmdText, "\n")
 			if i <= 0 {
 				break
 			}
 			uCmdText = uCmdText[i+1:]
+		} else if strings.HasPrefix(uCmdText, "/*") {
+			i := strings.Index(uCmdText, "*/")
+			if i <= 0 {
+				break
+			}
+			uCmdText = uCmdText[i+2:]
 		} else {
 			break
 		}

--- a/v2/command_test.go
+++ b/v2/command_test.go
@@ -1,0 +1,58 @@
+package go_ora
+
+import "testing"
+
+func TestNewStmt_WithComments(t *testing.T) {
+	t.Run("SELECT", func(t *testing.T) {
+		querySelectWithComments := `
+-- comment #1
+  -- comment #2
+/* comment #3 */
+  /* comment #4 */ select * from dual
+`
+
+		stmt := NewStmt(querySelectWithComments, nil)
+		if stmt == nil {
+			t.Errorf("no stmt returned")
+		} else if stmt.stmtType != SELECT {
+			t.Errorf("expected stmt.stmtType to be %v but was %v", SELECT, stmt.stmtType)
+		}
+	})
+
+	t.Run("UPDATE", func(t *testing.T) {
+		querySelectWithComments := `
+-- comment #1
+  -- comment #2
+/* comment #3 */
+  /* comment #4 */ update foo set bar = 1 where baz = 1
+`
+
+		stmt := NewStmt(querySelectWithComments, nil)
+		if stmt == nil {
+			t.Errorf("no stmt returned")
+		} else if stmt.stmtType != DML {
+			t.Errorf("expected stmt.stmtType to be %v but was %v", DML, stmt.stmtType)
+		}
+	})
+
+	t.Run("DECLARE", func(t *testing.T) {
+		querySelectWithComments := `
+-- comment #1
+  -- comment #2
+/* comment #3 */
+  /* comment #4 */ 
+DECLARE
+   foo NUMBER := 42;
+BEGIN
+   INSERT INTO bar VALUES (foo);
+END;
+`
+
+		stmt := NewStmt(querySelectWithComments, nil)
+		if stmt == nil {
+			t.Errorf("no stmt returned")
+		} else if stmt.stmtType != PLSQL {
+			t.Errorf("expected stmt.stmtType to be %v but was %v", PLSQL, stmt.stmtType)
+		}
+	})
+}


### PR DESCRIPTION
Running queries with leading comments such as `/* foo */` fail because of NewStmt not handling it. This change attempts to help fix that.

Fixes #46.

Note:
* This should be an easy fix with regexp, but I'm guessing you are not doing that for performance reasons. So I just added an `else if` block. Let me know if you want me to change the for loop to a regexp-based fix.
* I also noticed that you did not have ANY dependencies in your go.mod, so I avoided adding a dependency on asserts from `github.com/stretchr/testify/assert` and used simple built-checks in the unit-tests. Let me know if I should change this.