### PR TITLE
fixed timeout errors in advanced negotiation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -388,6 +388,8 @@ func (conn *Connection) OpenWithContext(ctx context.Context) error {
 	}
 
 	// advanced negotiation
+	session.StartContext(ctx)
+	defer session.EndContext()
 	if session.Context.ACFL0&1 != 0 && session.Context.ACFL0&4 == 0 && session.Context.ACFL1&8 == 0 {
 		tracer.Print("Advance Negotiation")
 		ano, err := advanced_nego.NewAdvNego(session)

--- a/network/session.go
+++ b/network/session.go
@@ -162,6 +162,9 @@ func (session *Session) StartContext(ctx context.Context) {
 	session.ctx = ctx
 }
 func (session *Session) EndContext() {
+	if session.oldCtx == nil {
+		session.oldCtx = context.Background()
+	}
 	session.ctx = session.oldCtx
 }
 

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -365,6 +365,8 @@ func (conn *Connection) OpenWithContext(ctx context.Context) error {
 		return err
 	}
 	// advanced negotiation
+	session.StartContext(ctx)
+	defer session.EndContext()
 	if session.Context.ACFL0&1 != 0 && session.Context.ACFL0&4 == 0 && session.Context.ACFL1&8 == 0 {
 		tracer.Print("Advance Negotiation")
 		ano, err := advanced_nego.NewAdvNego(session)

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -162,6 +162,9 @@ func (session *Session) StartContext(ctx context.Context) {
 	session.ctx = ctx
 }
 func (session *Session) EndContext() {
+	if session.oldCtx == nil {
+		session.oldCtx = context.Background()
+	}
 	session.ctx = session.oldCtx
 }
 


### PR DESCRIPTION
@sijms I've fixed the problem with advanced negotiation and included a fallback, so nil-pointer dereference should not happen anymore.
I've tested the connect/read/write timeouts in several scenarios and everything seems to be working as expected.