### PR TITLE
Add dialer in connection options

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -80,6 +80,7 @@ type Connection struct {
 type OracleConnector struct {
 	drv           *OracleDriver
 	connectString string
+	dialer        network.DialerContext
 }
 type OracleDriver struct {
 	//m         sync.Mutex
@@ -109,6 +110,7 @@ func (connector *OracleConnector) Connect(ctx context.Context) (driver.Conn, err
 	if err != nil {
 		return nil, err
 	}
+	conn.connOption.Dialer = connector.dialer
 	err = conn.OpenWithContext(ctx)
 	if err != nil {
 		return nil, err
@@ -118,6 +120,10 @@ func (connector *OracleConnector) Connect(ctx context.Context) (driver.Conn, err
 
 func (connector *OracleConnector) Driver() driver.Driver {
 	return connector.drv
+}
+
+func (connector *OracleConnector) Dialer(dialer network.DialerContext) {
+	connector.dialer = dialer
 }
 
 // Open return a new open connection

--- a/v2/network/connect_option.go
+++ b/v2/network/connect_option.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -39,6 +40,11 @@ type DatabaseInfo struct {
 	AuthType        int
 	connStr         string
 }
+
+type DialerContext interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
 type SessionInfo struct {
 	SSLVersion            string
 	Timeout               time.Duration
@@ -48,6 +54,7 @@ type SessionInfo struct {
 	Protocol              string
 	SSL                   bool
 	SSLVerify             bool
+	Dialer                DialerContext
 }
 type AdvNegoSeviceInfo struct {
 	AuthService []string

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -10,11 +10,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/trace"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/sijms/go-ora/v2/trace"
 
 	"github.com/sijms/go-ora/v2/converters"
 )
@@ -279,8 +280,11 @@ func (session *Session) Connect(ctx context.Context) error {
 	var connected = false
 	var host *ServerAddr
 	var loop = true
-	dialer := net.Dialer{
-		Timeout: time.Second * session.Context.ConnOption.Timeout,
+	dialer := connOption.Dialer
+	if dialer == nil {
+		dialer = &net.Dialer{
+			Timeout: time.Second * session.Context.ConnOption.Timeout,
+		}
 	}
 	for loop {
 		host = connOption.GetActiveServer(false)


### PR DESCRIPTION
Allows overriding the default net dialer from the connection options.

I had the need to set a custom dialer to connect to an Oracle DB. I follow the same approach implemented on other drivers like [postgreSQL](https://github.com/lib/pq/blob/v1.10.7/connector.go#L31) and [SQLServer](https://github.com/denisenkom/go-mssqldb/blob/v0.12.3/mssql.go#L181) by adding an option to set a dialer in the OracleConnector and use it in the session instead of the default net dialer.