### PR TITLE
Only negotiate SSL again for RESEND packet if mTLS (wallet) connection.

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -377,6 +377,7 @@ func (conn *Connection) OpenWithContext(ctx context.Context) error {
 	conn.session = network.NewSession(conn.connOption)
 	W := conn.conStr.w
 	if conn.connOption.SSL && W != nil {
+		conn.connOption.Wallet = true
 		err := conn.session.LoadSSLData(W.certificates, W.privateKeys, W.certificateRequests)
 		if err != nil {
 			return err

--- a/v2/network/connect_option.go
+++ b/v2/network/connect_option.go
@@ -55,6 +55,7 @@ type SessionInfo struct {
 	Protocol              string
 	SSL                   bool
 	SSLVerify             bool
+	Wallet                bool
 	Dialer                DialerContext
 }
 type AdvNegoSeviceInfo struct {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -606,6 +606,9 @@ func (session *Session) readPacket() (PacketInterface, error) {
 			}
 
 			if pckType == RESEND {
+				if session.Context.ConnOption.Wallet {
+					session.negotiate()
+				}
 				for _, pck := range session.sendPcks {
 					//log.Printf("Request: %#v\n\n", pck.bytes())
 					err := session.initWrite()

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -606,9 +606,6 @@ func (session *Session) readPacket() (PacketInterface, error) {
 			}
 
 			if pckType == RESEND {
-				if session.Context.ConnOption.SSL {
-					session.negotiate()
-				}
 				for _, pck := range session.sendPcks {
 					//log.Printf("Request: %#v\n\n", pck.bytes())
 					err := session.initWrite()


### PR DESCRIPTION
This is a fix for #299. Tested against Oracle Cloud Autonomous Transaction Processing Database versions 19c and 21c.