### PR TITLE
fixing concurrent bug causing by read/write access into global variable:

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -366,7 +366,7 @@ func (conn *Connection) restore() error {
 func (conn *Connection) OpenWithContext(ctx context.Context) error {
 
 	converters.Mutex.Lock()
-	defer converters.Mutex.Lock()
+	defer converters.Mutex.Unlock()
 
 	tracer := conn.connOption.Tracer
 	switch conn.conStr.DBAPrivilege {

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -364,6 +364,10 @@ func (conn *Connection) restore() error {
 
 // OpenWithContext open the connection with timeout context
 func (conn *Connection) OpenWithContext(ctx context.Context) error {
+
+	converters.Mutex.Lock()
+	defer converters.Mutex.Lock()
+
 	tracer := conn.connOption.Tracer
 	switch conn.conStr.DBAPrivilege {
 	case SYSDBA:

--- a/v2/converters/max_len.go
+++ b/v2/converters/max_len.go
@@ -1,5 +1,7 @@
 package converters
 
+import "sync"
+
 var (
 	MAX_LEN_VARCHAR2  int = 0x7FFF
 	MAX_LEN_NVARCHAR2     = 0x7FFF
@@ -8,3 +10,5 @@ var (
 	MAX_LEN_DATE          = 0xB
 	MAX_LEN_TIMESTAMP     = 0xB
 )
+
+var Mutex sync.RWMutex

--- a/v2/custom_types.go
+++ b/v2/custom_types.go
@@ -4,8 +4,9 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"github.com/sijms/go-ora/v2/converters"
 	"time"
+
+	"github.com/sijms/go-ora/v2/converters"
 )
 
 type ValueEncoder interface {
@@ -35,6 +36,9 @@ func (val *NVarChar) Scan(value interface{}) error {
 //}
 
 func (val *NVarChar) EncodeValue(param *ParameterInfo, connection *Connection) error {
+	converters.Mutex.Lock()
+	defer converters.Mutex.Unlock()
+
 	strVal := string(*val)
 	param.DataType = NCHAR
 	param.CharsetForm = 2

--- a/v2/parameter_encode.go
+++ b/v2/parameter_encode.go
@@ -130,6 +130,9 @@ func (par *ParameterInfo) encodeValue(val driver.Value, size int, connection *Co
 	par.CharsetForm = 1
 	par.BValue = nil
 
+	converters.Mutex.Lock()
+	defer converters.Mutex.Lock()
+
 	tempType := reflect.TypeOf(val)
 	if tempType.Kind() == reflect.Ptr {
 		tempType = tempType.Elem()

--- a/v2/parameter_encode.go
+++ b/v2/parameter_encode.go
@@ -131,7 +131,7 @@ func (par *ParameterInfo) encodeValue(val driver.Value, size int, connection *Co
 	par.BValue = nil
 
 	converters.Mutex.Lock()
-	defer converters.Mutex.Lock()
+	defer converters.Mutex.Unlock()
 
 	tempType := reflect.TypeOf(val)
 	if tempType.Kind() == reflect.Ptr {


### PR DESCRIPTION
Issue: #301 - Issue with Parameter Info when execute QueryContext with parameter encode
 
Solution: 
- Using mutex to block concurrent read/write into global variable in max_len.go 
- Apply the mutex block in parameter_encode.go when query is used with variable bind and access global variable (concurrent read).
- Apply the mutex block in connection,go when the connection open writes the global variable.
- Apply the mutex block in customer_types.go when EncodeValue() access to global variable (concurrent read)