### PR TITLE
Fix date and timestamp select

### DIFF
--- a/v2/converters/type_conversion.go
+++ b/v2/converters/type_conversion.go
@@ -564,7 +564,7 @@ func DecodeDate(data []byte) (time.Time, error) {
 	}
 	if tzHour == 0 && tzMin == 0 {
 		return time.Date(year, time.Month(data[2]), int(data[3]),
-			int(data[4]-1), int(data[5]-1), int(data[6]-1), nanoSec, time.UTC), nil
+			int(data[4]-1), int(data[5]-1), int(data[6]-1), nanoSec, time.Local), nil
 	}
 	var zone *time.Location
 	//var err error
@@ -620,8 +620,9 @@ func addDigitToMantissa(mantissaIn uint64, d byte) (mantissaOut uint64, carryOut
 // FromNumber decode Oracle binary representation of numbers
 // and returns mantissa, negative and exponent
 // Some documentation:
-//	https://gotodba.com/2015/03/24/how-are-numbers-saved-in-oracle/
-//  https://www.orafaq.com/wiki/Number
+//
+//		https://gotodba.com/2015/03/24/how-are-numbers-saved-in-oracle/
+//	 https://www.orafaq.com/wiki/Number
 func FromNumber(inputData []byte) (mantissa uint64, negative bool, exponent int, mantissaDigits int, err error) {
 	if len(inputData) == 0 {
 		return 0, false, 0, 0, fmt.Errorf("Invalid NUMBER")


### PR DESCRIPTION
An example of incorrect work
`func main() {
	err := godotenv.Load()
	if err != nil {
		log.Fatal("Error loading .env file")
	}
	server := os.Getenv("DB_SERVER")
	port, _ := strconv.Atoi(os.Getenv("DB_PORT"))
	service := os.Getenv("DB_SERVICE")
	user := os.Getenv("DB_USER")
	password := os.Getenv("DB_PASSWD")

	databaseURL := go_ora.BuildUrl(server, port, service, user, password, map[string]string{})
	db, err := sql.Open("oracle", databaseURL)
	if err != nil {
		log.Fatal("Error open database")
	}
	defer db.Close()
	_, err = db.Exec("create table date_test (db_date date, db_timestamp timestamp,db_timestamp_tz timestamp with time zone)")
	if err != nil {
		log.Println("Create table error:", err.Error())
	}
	ins, err := db.Prepare("insert into date_test values (:1,:2,:3)")
	if err != nil {
		log.Fatal("Error prepare database:", err.Error())
	}
	now := time.Now()
	_, err = ins.Exec(now, now, now)
	if err != nil {
		log.Fatal("Error insert database:", err.Error())
	}
	ins.Close()
	log.Println("Insert values", now.Format(time.RFC3339),
		now.Format(time.RFC3339), now.Format(time.RFC3339))
	rows, err := db.Query("select * from date_test")
	if err != nil {
		log.Fatal("Error select database:", err.Error())
	}
	for rows.Next() {
		var dbDate, dbTimestamp, dbTimestampWTZ time.Time
		err := rows.Scan(&dbDate, &dbTimestamp, &dbTimestampWTZ)
		if err != nil {
			log.Fatal("Error scan row:", err.Error())
		}
		log.Println("Select values", dbDate.Format(time.RFC3339),
			dbTimestamp.Format(time.RFC3339), dbTimestampWTZ.Format(time.RFC3339))
	}
	rows.Close()
	_, err = db.Exec("drop table date_test purge")
	if err != nil {
		log.Println("drop table error:", err.Error())
	}
}
`
Result without patch:
2023/02/23 17:36:46 Insert values 2023-02-23T17:36:46+02:00 2023-02-23T17:36:46+02:00 2023-02-23T17:36:46+02:00
2023/02/23 17:36:46 Select values 2023-02-23T17:36:46Z 2023-02-23T17:36:46Z 2023-02-23T17:36:46+02:00

Process finished with the exit code 0

With path:

2023/02/23 17:38:56 Insert values 2023-02-23T17:38:56+02:00 2023-02-23T17:38:56+02:00 2023-02-23T17:38:56+02:00
2023/02/23 17:38:56 Select values 2023-02-23T17:38:56+02:00 2023-02-23T17:38:56+02:00 2023-02-23T17:38:56+02:00

Process finished with the exit code 0