### PR TITLE
Implements the functions Length and DecimalSize of sql.ColumnType

### DIFF
--- a/v2/data_set.go
+++ b/v2/data_set.go
@@ -5,13 +5,14 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/network"
-	"github.com/sijms/go-ora/v2/trace"
 	"io"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sijms/go-ora/v2/network"
+	"github.com/sijms/go-ora/v2/trace"
 )
 
 // Compile time Sentinels for implemented Interfaces.
@@ -19,8 +20,8 @@ var _ = driver.Rows((*DataSet)(nil))
 var _ = driver.RowsColumnTypeDatabaseTypeName((*DataSet)(nil))
 var _ = driver.RowsColumnTypeLength((*DataSet)(nil))
 var _ = driver.RowsColumnTypeNullable((*DataSet)(nil))
+var _ = driver.RowsColumnTypePrecisionScale((*DataSet)(nil))
 
-// var _ = driver.RowsColumnTypePrecisionScale((*DataSet)(nil))
 // var _ = driver.RowsColumnTypeScanType((*DataSet)(nil))
 // var _ = driver.RowsNextResultSet((*DataSet)(nil))
 
@@ -498,21 +499,24 @@ func (dataSet DataSet) ColumnTypeDatabaseTypeName(index int) string {
 }
 
 // ColumnTypeLength return length of column type
-func (dataSet DataSet) ColumnTypeLength(index int) (length int64, ok bool) {
-	length = int64(len(dataSet.Cols[index].BValue))
-	ok = true
-	return
-	//switch dataSet.Cols[index].DataType {
-	//case NCHAR, CHAR:
-	//	return int64(dataSet.Cols[index].MaxCharLen), true
-	//case NUMBER:
-	//	return int64(dataSet.Cols[index].Precision), true
-	//}
-	//return int64(0), false
-
+func (dataSet DataSet) ColumnTypeLength(index int) (int64, bool) {
+	switch dataSet.Cols[index].DataType {
+	case NCHAR, CHAR:
+		return int64(dataSet.Cols[index].MaxCharLen), true
+	}
+	return int64(0), false
 }
 
 // ColumnTypeNullable return if column allow null or not
 func (dataSet DataSet) ColumnTypeNullable(index int) (nullable, ok bool) {
 	return dataSet.Cols[index].AllowNull, true
+}
+
+// ColumnTypePrecisionScale return the precision and scale for numeric types
+func (dataSet DataSet) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
+	switch dataSet.Cols[index].DataType {
+	case NUMBER:
+		return int64(dataSet.Cols[index].Precision), int64(dataSet.Cols[index].Scale), true
+	}
+	return int64(0), int64(0), false
 }


### PR DESCRIPTION
I found an issue with the query column types and I made a small change to fix it, It would be great if we could include it in the main repository.

This PR implements the function Length and DecimalSize of sql.ColumnType. Length was partially implemented with some code commented. I implemented it as documented in the `database/sql` package.

I used this test to validate the changes. Happy to add it to the `go_ora` package too, if it can be useful, but it's an integration test requiring a DB connection.

``` go
package main

import (
	"database/sql"
	"testing"

	_ "github.com/sijms/go-ora/v2"
)

const dns = "oracle://system:password@localhost:1521/XE"

func TestColumnLenPrecScale(t *testing.T) {
	for _, tt := range []struct {
		testName         string
		query            string
		expDBType        string
		expLength        int64
		expLengthOK      bool
		expPrecision     int64
		expScale         int64
		expDecimalSizeOK bool
		expNullable      bool
		expNullableOK    bool
	}{
		// characters
		{"char", "SELECT CAST('text' AS CHAR(10)) FROM DUAL", "CHAR", 10, true, 0, 0, false, true, true},
		{"nchar", "SELECT CAST('text' AS NCHAR(10)) FROM DUAL", "CHAR", 10, true, 0, 0, false, true, true},
		{"varchar", "SELECT CAST('text' AS VARCHAR(20)) FROM DUAL", "NCHAR", 20, true, 0, 0, false, true, true},
		{"varchar2", "SELECT CAST('text' AS VARCHAR2(20)) FROM DUAL", "NCHAR", 20, true, 0, 0, false, true, true},
		{"nvarchar2", "SELECT CAST('text' AS NVARCHAR2(20)) FROM DUAL", "NCHAR", 20, true, 0, 0, false, true, true},
		// numbers
		{"number", "SELECT CAST('123' AS NUMBER) FROM DUAL", "NUMBER", 0, false, 38, 255, true, true, true},
		{"number_5", "SELECT CAST(123 AS NUMBER(5)) FROM DUAL", "NUMBER", 0, false, 5, 0, true, true, true},
		{"number_5_3", "SELECT CAST(12.1 AS NUMBER(5,3)) FROM DUAL", "NUMBER", 0, false, 5, 3, true, true, true},
		{"numeric", "SELECT CAST('123' AS NUMERIC) FROM DUAL", "NUMBER", 0, false, 38, 0, true, true, true},
		{"numeric_5", "SELECT CAST(123 AS NUMERIC(5)) FROM DUAL", "NUMBER", 0, false, 5, 0, true, true, true},
		{"numeric_5_3", "SELECT CAST(12.1 AS NUMERIC(5,3)) FROM DUAL", "NUMBER", 0, false, 5, 3, true, true, true},
		{"decimal", "SELECT CAST('123' AS DECIMAL) FROM DUAL", "NUMBER", 0, false, 38, 0, true, true, true},
		{"decimal_5", "SELECT CAST(123 AS DECIMAL(5)) FROM DUAL", "NUMBER", 0, false, 5, 0, true, true, true},
		{"decimal_5_3", "SELECT CAST(12.1 AS DECIMAL(5,3)) FROM DUAL", "NUMBER", 0, false, 5, 3, true, true, true},
		{"float", "SELECT CAST('1.123' AS BINARY_FLOAT) FROM DUAL", "IBFloat", 0, false, 0, 0, false, true, true},
		{"double", "SELECT CAST('1.123' AS BINARY_DOUBLE) FROM DUAL", "IBDouble", 0, false, 0, 0, false, true, true},
		// raw
		{"guid", "SELECT SYS_GUID() FROM DUAL", "RAW", 0, false, 0, 0, false, true, true},
	} {
		t.Run(tt.testName, func(t *testing.T) {
			conn, err := sql.Open("oracle", dns)
			defer conn.Close()

			if err != nil {
				t.Errorf("%s - Open failed: %s", tt.testName, err)
				return
			}
			defer conn.Close()

			rows, err := conn.Query(tt.query)
			if err != nil {
				t.Errorf("%s - Query failed: %s", tt.testName, err)
				return
			}
			defer rows.Close()

			colTypes, err := rows.ColumnTypes()
			if err != nil {
				t.Errorf("%s - ColumnTypes failed: %s", tt.testName, err)
				return
			}
			if len(colTypes) != 1 {
				t.Errorf("%s - Expected one column: %s", tt.testName, err)
				return
			}
			colType := colTypes[0]
			// DatabaseTypeName
			if tt.expDBType != colType.DatabaseTypeName() {
				t.Errorf("%s: Expecting DB type %s, got %s", tt.testName, tt.expDBType, colType.DatabaseTypeName())
			}
			// Length
			len, ok := colType.Length()
			if tt.expLengthOK != ok {
				t.Errorf("%s: Expecting length OK %t, got %t", tt.testName, tt.expLengthOK, ok)
			}
			if tt.expLength != len {
				t.Errorf("%s: Expecting length %d, got %d", tt.testName, tt.expLength, len)
			}
			// DecimalSize
			precision, scale, ok := colType.DecimalSize()
			if tt.expDecimalSizeOK != ok {
				t.Errorf("%s: Expecting decimal-size OK %t, got %t", tt.testName, tt.expDecimalSizeOK, ok)
			}
			if tt.expPrecision != precision {
				t.Errorf("%s: Expecting precision %d, got %d", tt.testName, tt.expPrecision, precision)
			}
			if tt.expScale != scale {
				t.Errorf("%s: Expecting scale %d, got %d", tt.testName, tt.expScale, scale)
			}
			// Nullable
			null, ok := colType.Nullable()
			if tt.expNullableOK != ok {
				t.Errorf("%s: Expecting nullable OK %t, got %t", tt.testName, tt.expNullableOK, ok)
			}
			if tt.expNullable != null {
				t.Errorf("%s: Expecting nullable %t, got %t", tt.testName, tt.expNullable, null)
			}
		})
	}
}
```