### PR TITLE
Enable encoding of dates with nanoseconds

### DIFF
--- a/v2/converters/type_conversion.go
+++ b/v2/converters/type_conversion.go
@@ -1115,6 +1115,9 @@ var oracleZones = map[int]string{
 
 // EncodeDate convert time.Time into oracle representation
 func EncodeDate(ti time.Time) []byte {
+	if ti.Nanosecond() > 0 {
+		return EncodeTimeStamp(ti, false)
+	}
 	ret := make([]byte, 7)
 	ret[0] = uint8(ti.Year()/100 + 100)
 	ret[1] = uint8(ti.Year()%100 + 100)
@@ -1249,7 +1252,9 @@ func addDigitToMantissa(mantissaIn uint64, d byte) (mantissaOut uint64, carryOut
 //
 //		https://gotodba.com/2015/03/24/how-are-numbers-saved-in-oracle/
 //	 https://www.orafaq.com/wiki/Number
-func FromNumber(inputData []byte) (mantissa uint64, negative bool, exponent int, mantissaDigits int, err error) {
+func FromNumber(
+	inputData []byte,
+) (mantissa uint64, negative bool, exponent int, mantissaDigits int, err error) {
 	if len(inputData) == 0 {
 		return 0, false, 0, 0, fmt.Errorf("Invalid NUMBER")
 	}

--- a/v2/converters/type_conversion_test.go
+++ b/v2/converters/type_conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // Some documentation:
@@ -130,14 +131,29 @@ func TestEncodeDouble(t *testing.T) {
 	}
 }
 
-//
-// func TestEncodeDate(t *testing.T) {
-// 	ti := time.Date(2006, 01, 02, 15, 04, 06, 0, time.UTC)
+func TestEncodeDate(t *testing.T) {
+	// TODO: Probably worth testing different locations as well.
+	testCases := []time.Time{
+		time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+		time.Date(2006, 0, 0, 0, 0, 0, 0, time.UTC),
+		time.Date(2006, 1, 0, 0, 0, 0, 0, time.UTC),
+		time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2006, 1, 2, 15, 0, 0, 0, time.UTC),
+		time.Date(2006, 1, 2, 15, 4, 0, 0, time.UTC),
+		time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+		time.Date(2006, 1, 2, 15, 4, 5, 7, time.UTC),
+	}
 
-// 	got := EncodeDate(ti)
-// 	want := []byte{214, 7, 1, 2, 15, 4, 5, 0}
-
-// 	if !reflect.DeepEqual(got, want) {
-// 		t.Errorf("EncodeDate(%v) = %v, want %v", ti, got, want)
-// 	}
-// }
+	for _, tc := range testCases {
+		t.Run(tc.String(), func(t *testing.T) {
+			encoded := EncodeDate(tc)
+			decoded, err := DecodeDate(encoded)
+			if err != nil {
+				t.Error(err)
+			}
+			if !tc.Equal(decoded) {
+				t.Errorf("Original Date (%v) does not equal encoded then decoded date (%v)", tc, decoded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I found that nanoseconds were dropped if a time.Time contained them during encoding.  This should fix that, but there are clearly multiple way to do so.  

Let me know if you would like me to take an alternate approach.