### PR TITLE
Allow for tls connection without certificate (one-way TLS)

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -256,7 +256,7 @@ func (session *Session) LoadSSLData(certs, keys, certRequests [][]byte) error {
 // used to create sslConn object
 func (session *Session) negotiate() {
 	connOption := session.Context.ConnOption
-	if session.SSL.roots == nil {
+	if session.SSL.roots == nil && len(session.SSL.Certificates) > 0 {
 		session.SSL.roots = x509.NewCertPool()
 		for _, cert := range session.SSL.Certificates {
 			session.SSL.roots.AddCert(cert)
@@ -264,9 +264,13 @@ func (session *Session) negotiate() {
 	}
 	host := connOption.GetActiveServer(false)
 	config := &tls.Config{
-		Certificates: session.SSL.tlsCertificates,
-		RootCAs:      session.SSL.roots,
-		ServerName:   host.Addr,
+		ServerName: host.Addr,
+	}
+	if len(session.SSL.tlsCertificates) > 0 {
+		config.Certificates = session.SSL.tlsCertificates
+	}
+	if session.SSL.roots != nil {
+		config.RootCAs = session.SSL.roots
 	}
 	if !connOption.SSLVerify {
 		config.InsecureSkipVerify = true


### PR DESCRIPTION
This prevents certificate errors when trying to connect via TLS without a wallet.
Options that worked for me:

```
import (
	go_ora "github.com/sijms/go-ora/v2"

	oracle "github.com/godoes/gorm-oracle" // Only needed for GORM
	"gorm.io/gorm" // Only needed for GORM
)

	urlOptions := map[string]string{
		//"TRACE FILE": "trace.log",
		"AUTH TYPE":  "TCPS",
		"SSL":        "TRUE",
		"SSL VERIFY": "TRUE",
	}

```

Then I used JDBC string since "connStr" was the only  this I was sure was correct.

```
	jdbc := "(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=" + ORACLE_SERVER + "))(connect_data=(service_name=" + ORACLE_SERVICE + "))(security=(ssl_server_dn_match=yes)))"
	cleanJDBC := go_ora.BuildJDBC( ORACLE_USER ,  ORACLE_PASS), jdbc, urlOptions)

```
Using normal go-ora:

```
	conn, err := go_ora.NewConnection(cleanJDBC)
	if err != nil {
		log.Fatalln("Could not login: " + err.Error())
	}

	// check for error
	err = conn.Open()
	if err != nil {
		log.Fatalln("Could not login: " + err.Error())
	}
	// check for error
	defer conn.Close()
```


Using gorm:

```
	oracle.New(oracle.Config{})
	db, err := gorm.Open(oracle.Open(cleanJDBC), &gorm.Config{})
	if err != nil {
		log.Fatalln("Could not login: " + err.Error())
	}
```


I assume normal sql should work as intended, I needed GORM so I was happy it worked immediately.
