### PR TITLE
When there is an issue with the user's permissions, it can cause an error to be reported

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -136,7 +136,7 @@ DECLARE
 				:p_nls_numeric_chars, :p_nls_dual_currency, :p_nls_timestamp, :p_nls_timestamp_tz,
 				:p_err_code, :p_err_msg
 		FROM
-			nls_session_parameters
+			sys.nls_session_parameters
 		;
 	END;`
 	stmt := NewStmt(cmdText, conn)

--- a/connection.go
+++ b/connection.go
@@ -109,7 +109,7 @@ func (conn *Connection) SetStringConverter(converter converters.IStringConverter
 
 func (conn *Connection) GetNLS() (*NLSData, error) {
 
-	// we read from nls_session_parameters ONCE
+	// we read from sys.nls_session_parameters ONCE
 	cmdText := `
 DECLARE
 	err_code VARCHAR2(2000);

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -162,7 +162,7 @@ func (conn *Connection) SetStringConverter(converter converters.IStringConverter
 // this function is left from v1. but v2 is using another method
 func (conn *Connection) GetNLS() (*NLSData, error) {
 
-	// we read from nls_session_parameters ONCE
+	// we read from sys.nls_session_parameters ONCE
 	cmdText := `
 	BEGIN
 		SELECT 
@@ -183,7 +183,7 @@ func (conn *Connection) GetNLS() (*NLSData, error) {
 				:p_nls_date_lang, :p_nls_sort, :p_nls_currency, :p_nls_date_format, :p_nls_iso_currency,
 				:p_nls_numeric_chars, :p_nls_dual_currency, :p_nls_timestamp, :p_nls_timestamp_tz
 		FROM
-			nls_session_parameters
+			sys.nls_session_parameters
 		;
 	END;`
 	stmt := NewStmt(cmdText, conn)


### PR DESCRIPTION
Error:ORA-06550: line 21, column 4:
PL/SQL: ORA-00980: synonym translation is no longer valid
ORA-06550: line 3, column 3:
PL/SQL: SQL Statement ignored