### PR TITLE
go-ora/v2/network: Reserve additional packet space for NNE

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -538,7 +538,7 @@ func (session *Session) Write() error {
 		//return errors.New("the output buffer is empty")
 	}
 
-	segmentLen := int(session.Context.SessionDataUnit - 20)
+	segmentLen := int(session.Context.SessionDataUnit - 64)
 	offset := 0
 	if size > segmentLen {
 		segment := make([]byte, segmentLen)


### PR DESCRIPTION
This change increases the amount of space that is reserved for Native Network Encrpytion checksums and encryption overhead. Without this change, clients sending large buffers to the server can experience arbitrary disconnections since the resulting data packet may exceed the SessionDataUnit size.

This change has been spot-checked with Oracle Database 19c and 21c with the following lines in the `sqlnet.ora` file:

```
SQLNET.ENCRYPTION_SERVER = REQUIRED
SQLNET.ENCRYPTION_TYPES_SERVER = AES256
SQLNET.ENCRYPTION_CLIENT = REQUIRED
SQLNET.ENCRYPTION_TYPES_CLIENT = AES256
SQLNET.CRYPTO_CHECKSUM_SERVER = REQUIRED
SQLNET.CRYPTO_CHECKSUM_TYPES_SERVER = SHA256
SQLNET.CRYPTO_CHECKSUM_TYPES_CLIENT = SHA256
SQLNET.CRYPTO_CHECKSUM_CLIENT  = REQUIRED
SQLNET.EXPIRE_TIME = 10
```

Fixes #444