### PR TITLE
Augment bad connection management

### DIFF
--- a/v2/command.go
+++ b/v2/command.go
@@ -8,11 +8,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/network"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/sijms/go-ora/v2/network"
 )
 
 type StmtType int
@@ -568,6 +569,7 @@ func (stmt *defaultStmt) fetch(dataSet *DataSet) error {
 	var err = stmt._fetch(dataSet)
 	if err != nil {
 		if isBadConn(err) {
+			stmt.connection.setBad()
 			tracer.Print("Error: ", err)
 			return driver.ErrBadConn
 		}
@@ -2213,6 +2215,7 @@ func (stmt *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	}
 	if err != nil {
 		if isBadConn(err) {
+			stmt.connection.setBad()
 			tracer.Print("Error: ", err)
 			return nil, driver.ErrBadConn
 		}
@@ -2326,6 +2329,7 @@ func (stmt *Stmt) Query_(namedArgs []driver.NamedValue) (*DataSet, error) {
 	dataSet, err := stmt._query()
 	if err != nil {
 		if isBadConn(err) {
+			stmt.connection.setBad()
 			tracer.Print("Error: ", err)
 			return nil, driver.ErrBadConn
 		}

--- a/v2/network/oracle_error.go
+++ b/v2/network/oracle_error.go
@@ -50,3 +50,12 @@ func (err *OracleError) translate() {
 		err.ErrMsg = "ORA-" + strconv.Itoa(err.ErrCode)
 	}
 }
+
+func (err *OracleError) Bad() bool {
+	switch err.ErrCode {
+	case 28, 1012, 1033, 1034, 1089, 3113, 3114, 3135, 12528, 12537:
+		return true
+	default:
+		return false
+	}
+}

--- a/v2/ref_cursor.go
+++ b/v2/ref_cursor.go
@@ -2,6 +2,7 @@ package go_ora
 
 import (
 	"database/sql/driver"
+
 	"github.com/sijms/go-ora/v2/network"
 )
 
@@ -142,6 +143,7 @@ func (cursor *RefCursor) Query() (*DataSet, error) {
 	dataSet, err := cursor._query()
 	if err != nil {
 		if isBadConn(err) {
+			cursor.connection.setBad()
 			tracer.Print("Error: ", err)
 			return nil, driver.ErrBadConn
 		}

--- a/v2/simple_object.go
+++ b/v2/simple_object.go
@@ -57,6 +57,7 @@ func (obj *simpleObject) exec() error {
 	var err = obj.write().read()
 	if err != nil {
 		if isBadConn(err) {
+			obj.connection.setBad()
 			tracer.Print("Error: ", err)
 			return driver.ErrBadConn
 		}


### PR DESCRIPTION
Fixes #455 

This set of changes primarily does 3 things:

1. Changes the "bad" connection indicator to be something that can be atomically managed.
2. Sets the connection to be "bad" in every place that isBadConn(err) says that the connection is bad.
3. Augments the OracleError type to have a Bad() method so that oracle error codes indicating that the connection is invalid are stored in one place.