### PR TITLE
Added tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 *.log
 .DS_Store
+.idea/

--- a/v2/module_test/go.mod
+++ b/v2/module_test/go.mod
@@ -1,0 +1,7 @@
+module v2_test
+
+go 1.17
+
+replace github.com/sijms/go-ora/v2 => ../
+
+require github.com/sijms/go-ora/v2 v2.0.0-00010101000000-000000000000

--- a/v2/module_test/int_test.go
+++ b/v2/module_test/int_test.go
@@ -1,0 +1,223 @@
+package v2_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+var sqlColNamesTestDataTypeInt = []string{"id",
+	"data_int", "data_integer", "data_decimal", "data_number", "data_numeric",
+	"data_tinyint", "data_smallint", "data_mediumint", "data_bigint",
+	"data_int1", "data_int2", "data_int4", "data_int8"}
+
+func TestDataType_Int(t *testing.T) {
+	testName := "TestDataType_Int"
+	db, err := newDbConnection()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if db == nil {
+		t.Skipf("%s skipped", testName)
+	}
+	defer func() { _ = db.Close() }()
+
+	tblName := "test_int"
+	colNameList := sqlColNamesTestDataTypeInt
+	colTypes := []string{"NVARCHAR2(8)",
+		"INT", "INTEGER", "NUMERIC(38,0)", "NUMBER(38,0)", "DECIMAL(38,0)",
+		"NUMERIC(3,0)", "SMALLINT", "DECIMAL(19,0)", "DEC(38,0)",
+		"DEC(4,0)", "NUMBER(8,0)", "DECIMAL(16,0)", "NUMERIC(32,0)"}
+	type Row struct {
+		id            string
+		dataInt       int
+		dataInteger   int
+		dataDecimal   int
+		dataNumber    int
+		dataNumeric   int
+		dataTinyInt   int8
+		dataSmallInt  int16
+		dataMediumInt int32
+		dataBigInt    int64
+		dataInt1      int8
+		dataInt2      int16
+		dataInt4      int32
+		dataInt8      int64
+	}
+
+	// init table
+	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tblName))
+	sql := fmt.Sprintf("CREATE TABLE %s (", tblName)
+	for i := range colNameList {
+		sql += colNameList[i] + " " + colTypes[i] + ","
+	}
+	sql += fmt.Sprintf("PRIMARY KEY(%s))", colNameList[0])
+	if _, err := db.Exec(sql); err != nil {
+		t.Fatalf("%s failed: %s\n%s", testName, err, sql)
+	}
+
+	rowArr := make([]Row, 0)
+	numRows := 100
+	// insert some rows
+	sql = fmt.Sprintf("INSERT INTO %s (", tblName)
+	sql += strings.Join(colNameList, ",")
+	sql += ") VALUES ("
+	sql += generatePlaceholders(len(colNameList)) + ")"
+	for i := 1; i <= numRows; i++ {
+		vInt := rand.Int63()
+		row := Row{
+			id:            fmt.Sprintf("%03d", i),
+			dataInt:       int(vInt%(2^32)) + 1,
+			dataInteger:   int(vInt%(2^32)) + 2,
+			dataDecimal:   int(vInt%(2^32)) + 3,
+			dataNumber:    int(vInt%(2^32)) + 4,
+			dataNumeric:   int(vInt%(2^32)) + 5,
+			dataTinyInt:   int8(vInt%(2^8)) + 6,
+			dataSmallInt:  int16(vInt%(2^16)) + 7,
+			dataMediumInt: int32(vInt%(2^24)) + 8,
+			dataBigInt:    vInt - 1,
+			dataInt1:      int8(vInt%(2^8)) + 9,
+			dataInt2:      int16(vInt%(2^16)) + 10,
+			dataInt4:      int32(vInt%(2^24)) + 11,
+			dataInt8:      vInt - 2,
+		}
+		rowArr = append(rowArr, row)
+		params := []interface{}{row.id,
+			row.dataInt, row.dataInteger, row.dataDecimal, row.dataNumber, row.dataNumeric,
+			row.dataTinyInt, row.dataSmallInt, row.dataMediumInt, row.dataBigInt,
+			row.dataInt1, row.dataInt2, row.dataInt4, row.dataInt8}
+		_, err := db.Exec(sql, params...)
+		if err != nil {
+			fmt.Printf("%s\n%#v\n", sql, params)
+			t.Fatalf("%s failed: row: %d / error: %s", testName, i, err)
+		}
+	}
+
+	// query some rows
+	sql = fmt.Sprintf("SELECT * FROM %s ORDER BY id", tblName)
+	dbRows, err := db.Query(sql)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	rows, err := fetchAllRowsColumnLowerCased(dbRows)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+
+	for i, row := range rows {
+		expected := rowArr[i]
+		{
+			f := "id"
+			e := expected.id
+			v, ok := row[f].(string)
+			if !ok || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v but received %#v", testName, f, e, row[f])
+			}
+		}
+		{
+			e := int64(expected.dataInt)
+			f := colNameList[1]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataInteger)
+			f := colNameList[2]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataDecimal)
+			f := colNameList[3]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataNumber)
+			f := colNameList[4]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataNumeric)
+			f := colNameList[5]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataTinyInt)
+			f := colNameList[6]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataSmallInt)
+			f := colNameList[7]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataMediumInt)
+			f := colNameList[8]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataBigInt)
+			f := colNameList[9]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataInt1)
+			f := colNameList[10]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataInt2)
+			f := colNameList[11]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataInt4)
+			f := colNameList[12]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+		{
+			e := int64(expected.dataInt8)
+			f := colNameList[13]
+			v, err := toIntIfInteger(row[f])
+			if err != nil || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, e, e, row[f], row[f], err)
+			}
+		}
+	}
+}

--- a/v2/module_test/money_test.go
+++ b/v2/module_test/money_test.go
@@ -1,0 +1,132 @@
+package v2_test
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+var sqlColNamesTestDataTypeMoney = []string{"id", "data_money2", "data_money4", "data_money6", "data_money8"}
+
+func TestDataType_Money(t *testing.T) {
+	testName := "TestDataType_Money"
+	db, err := newDbConnection()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if db == nil {
+		t.Skipf("%s skipped", testName)
+	}
+	defer func() { _ = db.Close() }()
+
+	tblName := "test_money"
+	colNameList := sqlColNamesTestDataTypeMoney
+	colTypes := []string{"NVARCHAR2(8)", "NUMERIC(24,2)", "DECIMAL(28,4)", "DEC(32,6)", "NUMERIC(36,8)"}
+	type Row struct {
+		id         string
+		dataMoney2 float64
+		dataMoney4 float64
+		dataMoney6 float64
+		dataMoney8 float64
+	}
+
+	// init table
+	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tblName))
+	sql := fmt.Sprintf("CREATE TABLE %s (", tblName)
+	for i := range colNameList {
+		sql += colNameList[i] + " " + colTypes[i] + ","
+	}
+	sql += fmt.Sprintf("PRIMARY KEY(%s))", colNameList[0])
+	if _, err := db.Exec(sql); err != nil {
+		t.Fatalf("%s failed: %s\n%s", testName, err, sql)
+	}
+
+	rowArr := make([]Row, 0)
+	numRows := 100
+	// insert some rows
+	sql = fmt.Sprintf("INSERT INTO %s (", tblName)
+	sql += strings.Join(colNameList, ",")
+	sql += ") VALUES ("
+	sql += generatePlaceholders(len(colNameList)) + ")"
+	for i := 1; i <= numRows; i++ {
+		//vMoneySmall := float64(rand.Intn(65536)) + rand.Float64()
+		//vMoneyLarge := float64(rand.Int31()) + rand.Float64()
+		vMoneySmall := float64(rand.Intn(65536))
+		vMoneyLarge := float64(rand.Int31())
+		row := Row{
+			id:         fmt.Sprintf("%03d", i),
+			dataMoney2: math.Round(vMoneySmall*1e2) / 1e2,
+			dataMoney4: math.Round(vMoneySmall*1e4) / 1e4,
+			dataMoney6: math.Round(vMoneyLarge*1e6) / 1e6,
+			dataMoney8: math.Round(vMoneyLarge*1e8) / 1e8,
+		}
+		rowArr = append(rowArr, row)
+		params := []interface{}{row.id, row.dataMoney2, row.dataMoney4, row.dataMoney6, row.dataMoney8}
+		_, err := db.Exec(sql, params...)
+		if err != nil {
+			fmt.Printf("%s\n%#v\n", sql, params)
+			t.Fatalf("%s failed: row: %d / error: %s", testName, i, err)
+		}
+	}
+
+	// query some rows
+	sql = fmt.Sprintf("SELECT * FROM %s ORDER BY id", tblName)
+	dbRows, err := db.Query(sql)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	rows, err := fetchAllRowsColumnLowerCased(dbRows)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+
+	for i, row := range rows {
+		expected := rowArr[i]
+		{
+			f := "id"
+			e := expected.id
+			v, ok := row[f].(string)
+			if !ok || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v but received %#v", testName, f, e, row[f])
+			}
+		}
+		{
+			e := expected.dataMoney2
+			f := colNameList[1]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.2f", e), fmt.Sprintf("%.2f", v); err != nil || vstr != estr {
+				fmt.Printf("DEBUG: Row #%s / From db table: %#v(%.10f) / Expected: %#v(%.10f)\n", row["id"], row[f], row[f], e, e)
+				t.Fatalf("%s failed: [%s] expected %#v/%.10f(%T) but received %#v/%.10f(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, e, vstr, v, row[f], err)
+			}
+		}
+		{
+			e := expected.dataMoney4
+			f := colNameList[2]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.4f", e), fmt.Sprintf("%.4f", v); err != nil || vstr != estr {
+				fmt.Printf("DEBUG: Row #%s / From db table: %#v(%.10f) / Expected: %#v(%.10f)\n", row["id"], row[f], row[f], e, e)
+				t.Fatalf("%s failed: [%s] expected %#v/%.10f(%T) but received %#v/%.10f(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, e, vstr, v, row[f], err)
+			}
+		}
+		{
+			e := expected.dataMoney6
+			f := colNameList[3]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.6f", e), fmt.Sprintf("%.6f", v); err != nil || vstr != estr {
+				fmt.Printf("DEBUG: Row #%s / From db table: %#v(%.10f) / Expected: %#v(%.10f)\n", row["id"], row[f], row[f], e, e)
+				t.Fatalf("%s failed: [%s] expected %#v/%.10f(%T) but received %#v/%.10f(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, e, vstr, v, row[f], err)
+			}
+		}
+		{
+			e := expected.dataMoney8
+			f := colNameList[4]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.8f", e), fmt.Sprintf("%.8f", v); err != nil || vstr != estr {
+				fmt.Printf("DEBUG: Row #%s / From db table: %#v (%.10f) / Expected: %#v (%.10f)\n", row["id"], row[f], row[f], e, e)
+				t.Fatalf("%s failed: [%s] expected %#v/%.10f(%T) but received %#v/%.10f(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, e, vstr, v, row[f], err)
+			}
+		}
+	}
+}

--- a/v2/module_test/real_test.go
+++ b/v2/module_test/real_test.go
@@ -1,0 +1,374 @@
+package v2_test
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
+
+var sqlColNamesTestDataTypeReal = []string{"id",
+	"data_float", "data_double", "data_real",
+	"data_decimal", "data_number", "data_numeric",
+	"data_float32", "data_float64",
+	"data_float4", "data_float8"}
+
+func TestDataType_Real(t *testing.T) {
+	testName := "TestDataType_Real"
+	db, err := newDbConnection()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if db == nil {
+		t.Skipf("%s skipped", testName)
+	}
+	defer func() { _ = db.Close() }()
+
+	tblName := "test_real"
+	colNameList := sqlColNamesTestDataTypeReal
+	colTypes := []string{"NVARCHAR2(8)",
+		"FLOAT", "DOUBLE PRECISION", "REAL",
+		"DECIMAL(38,6)", "NUMBER(38,6)", "NUMERIC(38,6)",
+		"BINARY_FLOAT", "BINARY_DOUBLE",
+		"BINARY_FLOAT", "BINARY_DOUBLE"}
+	type Row struct {
+		id          string
+		dataFloat   float64
+		dataDouble  float64
+		dataReal    float64
+		dataDecimal float64
+		dataNumber  float64
+		dataNumeric float64
+		dataFloat32 float32
+		dataFloat64 float64
+		dataFloat4  float32
+		dataFloat8  float64
+	}
+
+	// init table
+	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tblName))
+	sql := fmt.Sprintf("CREATE TABLE %s (", tblName)
+	for i := range colNameList {
+		sql += colNameList[i] + " " + colTypes[i] + ","
+	}
+	sql += fmt.Sprintf("PRIMARY KEY(%s))", colNameList[0])
+	if _, err := db.Exec(sql); err != nil {
+		t.Fatalf("%s failed: %s\n%s", testName, err, sql)
+	}
+
+	rowArr := make([]Row, 0)
+	numRows := 100
+	// insert some rows
+	sql = fmt.Sprintf("INSERT INTO %s (", tblName)
+	sql += strings.Join(colNameList, ",")
+	sql += ") VALUES ("
+	sql += generatePlaceholders(len(colNameList)) + ")"
+	for i := 1; i <= numRows; i++ {
+		vReal := 0.123456789
+		row := Row{
+			id:          fmt.Sprintf("%03d", i),
+			dataFloat:   math.Round(vReal*1e6) / 1e6,
+			dataDouble:  math.Round(vReal*1e6) / 1e6,
+			dataReal:    math.Round(vReal*1e6) / 1e6,
+			dataDecimal: math.Round(vReal*1e6) / 1e6,
+			dataNumber:  math.Round(vReal*1e6) / 1e6,
+			dataNumeric: math.Round(vReal*1e6) / 1e6,
+			dataFloat32: float32(math.Round(vReal*1e4) / 1e4),
+			dataFloat64: math.Round(vReal*1e8) / 1e8,
+			dataFloat4:  float32(math.Round(vReal*1e4) / 1e4),
+			dataFloat8:  math.Round(vReal*1e8) / 1e8,
+		}
+		rowArr = append(rowArr, row)
+		params := []interface{}{row.id, row.dataFloat, row.dataDouble, row.dataReal,
+			row.dataDecimal, row.dataNumeric, row.dataNumeric,
+			row.dataFloat32, row.dataFloat64, row.dataFloat4, row.dataFloat8}
+		_, err := db.Exec(sql, params...)
+		if err != nil {
+			fmt.Printf("%s\n%#v\n", sql, params)
+			t.Fatalf("%s failed: row: %d / error: %s", testName, i, err)
+		}
+	}
+
+	// query some rows
+	sql = fmt.Sprintf("SELECT * FROM %s ORDER BY id", tblName)
+	dbRows, err := db.Query(sql)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	rows, err := fetchAllRowsColumnLowerCased(dbRows)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+
+	for i, row := range rows {
+		expected := rowArr[i]
+		{
+			f := "id"
+			e := expected.id
+			v, ok := row[f].(string)
+			if !ok || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v but received %#v", testName, f, e, row[f])
+			}
+		}
+		{
+			e := expected.dataFloat
+			f := colNameList[1]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataDouble
+			f := colNameList[2]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataReal
+			f := colNameList[3]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataDecimal
+			f := colNameList[4]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataNumber
+			f := colNameList[5]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataNumeric
+			f := colNameList[6]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat32
+			f := colNameList[7]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat64
+			f := colNameList[8]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat4
+			f := colNameList[9]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat8
+			f := colNameList[10]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+	}
+}
+
+func TestDataType_RealNonFraction(t *testing.T) {
+	testName := "TestDataType_RealNonFraction"
+	db, err := newDbConnection()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if db == nil {
+		t.Skipf("%s skipped", testName)
+	}
+	defer func() { _ = db.Close() }()
+
+	tblName := "test_real"
+	colNameList := sqlColNamesTestDataTypeReal
+	colTypes := []string{"NVARCHAR2(8)",
+		"FLOAT", "DOUBLE PRECISION", "REAL",
+		"DECIMAL(38,6)", "NUMBER(38,6)", "NUMERIC(38,6)",
+		"BINARY_FLOAT", "BINARY_DOUBLE",
+		"BINARY_FLOAT", "BINARY_DOUBLE"}
+	type Row struct {
+		id          string
+		dataFloat   float64
+		dataDouble  float64
+		dataReal    float64
+		dataDecimal float64
+		dataNumber  float64
+		dataNumeric float64
+		dataFloat32 float32
+		dataFloat64 float64
+		dataFloat4  float32
+		dataFloat8  float64
+	}
+
+	// init table
+	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tblName))
+	sql := fmt.Sprintf("CREATE TABLE %s (", tblName)
+	for i := range colNameList {
+		sql += colNameList[i] + " " + colTypes[i] + ","
+	}
+	sql += fmt.Sprintf("PRIMARY KEY(%s))", colNameList[0])
+	if _, err := db.Exec(sql); err != nil {
+		t.Fatalf("%s failed: %s\n%s", testName, err, sql)
+	}
+
+	rowArr := make([]Row, 0)
+	numRows := 100
+	// insert some rows
+	sql = fmt.Sprintf("INSERT INTO %s (", tblName)
+	sql += strings.Join(colNameList, ",")
+	sql += ") VALUES ("
+	sql += generatePlaceholders(len(colNameList)) + ")"
+	for i := 1; i <= numRows; i++ {
+		vReal := float64(12345)
+		row := Row{
+			id:          fmt.Sprintf("%03d", i),
+			dataFloat:   math.Round(vReal*1e6) / 1e6,
+			dataDouble:  math.Round(vReal*1e6) / 1e6,
+			dataReal:    math.Round(vReal*1e6) / 1e6,
+			dataDecimal: math.Round(vReal*1e6) / 1e6,
+			dataNumber:  math.Round(vReal*1e6) / 1e6,
+			dataNumeric: math.Round(vReal*1e6) / 1e6,
+			dataFloat32: float32(math.Round(vReal*1e4) / 1e4),
+			dataFloat64: math.Round(vReal*1e8) / 1e8,
+			dataFloat4:  float32(math.Round(vReal*1e4) / 1e4),
+			dataFloat8:  math.Round(vReal*1e8) / 1e8,
+		}
+		rowArr = append(rowArr, row)
+		params := []interface{}{row.id, row.dataFloat, row.dataDouble, row.dataReal,
+			row.dataDecimal, row.dataNumeric, row.dataNumeric,
+			row.dataFloat32, row.dataFloat64, row.dataFloat4, row.dataFloat8}
+		_, err := db.Exec(sql, params...)
+		if err != nil {
+			fmt.Printf("%s\n%#v\n", sql, params)
+			t.Fatalf("%s failed: row: %d / error: %s", testName, i, err)
+		}
+	}
+
+	// query some rows
+	sql = fmt.Sprintf("SELECT * FROM %s ORDER BY id", tblName)
+	dbRows, err := db.Query(sql)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	rows, err := fetchAllRowsColumnLowerCased(dbRows)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+
+	for i, row := range rows {
+		expected := rowArr[i]
+		{
+			f := "id"
+			e := expected.id
+			v, ok := row[f].(string)
+			if !ok || v != e {
+				t.Fatalf("%s failed: [%s] expected %#v but received %#v", testName, f, e, row[f])
+			}
+		}
+		{
+			e := expected.dataFloat
+			f := colNameList[1]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataDouble
+			f := colNameList[2]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataReal
+			f := colNameList[3]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataDecimal
+			f := colNameList[4]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataNumber
+			f := colNameList[5]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataNumeric
+			f := colNameList[6]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat32
+			f := colNameList[7]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat64
+			f := colNameList[8]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat4
+			f := colNameList[9]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+		{
+			e := expected.dataFloat8
+			f := colNameList[10]
+			v, err := toFloatIfReal(row[f])
+			if estr, vstr := fmt.Sprintf("%.f", e), fmt.Sprintf("%.f", v); err != nil || vstr != estr {
+				t.Fatalf("%s failed: [%s] expected %#v(%T) but received %#v(%T) (error: %s)", testName, row["id"].(string)+"/"+f, estr, e, vstr, row[f], err)
+			}
+		}
+	}
+}

--- a/v2/module_test/sql_test.go
+++ b/v2/module_test/sql_test.go
@@ -1,0 +1,141 @@
+package v2_test
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	_ "github.com/sijms/go-ora/v2"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func generatePlaceholders(n int) string {
+	result := ""
+	for i := 1; i < n; i++ {
+		result += ":" + strconv.Itoa(i) + ","
+	}
+	result += ":" + strconv.Itoa(n)
+	return result
+}
+
+func newDbConnection() (*sql.DB, error) {
+	driver := "oracle"
+	dsn := os.Getenv("ORACLE_DSN")
+	if dsn == "" {
+		return nil, nil
+	}
+	return sql.Open(driver, dsn)
+}
+
+func fetchOneRow(rows *sql.Rows, colsAndTypes []*sql.ColumnType) (map[string]interface{}, error) {
+	numCols := len(colsAndTypes)
+	vals := make([]interface{}, numCols)
+	scanVals := make([]interface{}, numCols)
+	for i := 0; i < numCols; i++ {
+		scanVals[i] = &vals[i]
+	}
+	if err := rows.Scan(scanVals...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	result := map[string]interface{}{}
+	for i, col := range colsAndTypes {
+		result[strings.ToLower(col.Name())] = vals[i]
+	}
+	return result, nil
+}
+
+func fetchAllRowsColumnLowerCased(dbrows *sql.Rows) ([]map[string]interface{}, error) {
+	defer func() { _ = dbrows.Close() }()
+
+	colTypes, err := dbrows.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, 0)
+	for dbrows.Next() {
+		rowData, err := fetchOneRow(dbrows, colTypes)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rowData)
+	}
+	return result, dbrows.Err()
+}
+
+func toIntIfInteger(v interface{}) (int64, error) {
+	if v == nil {
+		return 0, errors.New("input is nil")
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(rv.Uint()), nil
+	default:
+		fmt.Printf("[DEBUG] - toIntIfInteger: %#v(%T)\n", v, v)
+		return 0, errors.New("input is not integer")
+	}
+}
+
+func toFloatIfReal(v interface{}) (float64, error) {
+	if v == nil {
+		return 0, errors.New("input is nil")
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), nil
+	default:
+		fmt.Printf("[DEBUG] toFloatIfReal: %#v(%T)\n", v, v)
+		return 0, errors.New("input is not real number")
+	}
+}
+
+func toFloatIfNumber(v interface{}) (float64, error) {
+	if v == nil {
+		return 0, errors.New("input is nil")
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(rv.Int()), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(rv.Uint()), nil
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), nil
+	default:
+		fmt.Printf("[DEBUG] toFloatIfNumber: %#v(%T)\n", v, v)
+		return 0, errors.New("input is not valid number")
+	}
+}
+
+const (
+	timezoneSql  = "Asia/Kabul"
+	timezoneSql2 = "Europe/Rome"
+)
+
+func TestPing(t *testing.T) {
+	testName := "TestPing"
+	db, err := newDbConnection()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if db == nil {
+		t.Skipf("%s skipped", testName)
+	}
+	defer func() { _ = db.Close() }()
+
+	err = db.Ping()
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+}


### PR DESCRIPTION
- Tests are organized in their own package under directory `v2/module_test/`.
- Tests added in this PR: tests for integers, real numbers and money data types.

Start an Oracle instance locally with Docker:

```sh
$ docker run --restart unless-stopped -d --name oracle-xe -p 1521:1521 -e ORACLE_PWD=SecretPassword1 container-registry.oracle.com/database/express:21.3.0-xe
```

Run tests:

```sh
$ export ORACLE_DSN="oracle://system:SecretPassword1@localhost:1521/?SID=XE"
$ cd v2/module_test
$ go test -v -count 1 -p 1 ./
```

P/S: if a value stored in a floating point column (e.g. `NUMERIC(x,y)`) have zero fraction part (e.g. `123.00`) then it is fetched as an integer (e.g. Go's `int/uint`).
I consider this is a bug because the fetched value should be in Go's `float32/float64`. Hence some tests currently fails.