### PR TITLE
Interrupt a running operation

### DIFF
--- a/v2/connection_string.go
+++ b/v2/connection_string.go
@@ -620,6 +620,8 @@ func newConnectionStringFromUrl(databaseUrl string) (*ConnectionString, error) {
 			if err != nil {
 				return nil, err
 			}
+		case "DISABLE URGENT DATA TRANSPORT":
+			ret.connOption.DisableUrgentDataTransport = 1024
 		default:
 			return nil, fmt.Errorf("unknown URL option: %s", key)
 			//else if tempVal == "IMPLICIT" || tempVal == "AUTO" {

--- a/v2/driver.go
+++ b/v2/driver.go
@@ -72,7 +72,7 @@ func (driver *OracleDriver) init(conn *Connection) error {
 	// update session parameters
 	var err error
 	for key, value := range driver.sessionParam {
-		_, err = conn.Exec(fmt.Sprintf("alter session set %s='%s'", key, value))
+		_, err = conn.Exec(fmt.Sprintf("alter session set %s=%s", key, value))
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func DelSessionParam(db *sql.DB, key string) {
 	}
 }
 func AddSessionParam(db *sql.DB, key, value string) error {
-	_, err := db.Exec(fmt.Sprintf("alter session set %s='%s'", key, value))
+	_, err := db.Exec(fmt.Sprintf("alter session set %s=%s", key, value))
 	if err != nil {
 		return err
 	}

--- a/v2/network/connect_option.go
+++ b/v2/network/connect_option.go
@@ -71,11 +71,12 @@ type ConnectionOption struct {
 	DatabaseInfo
 	SessionInfo
 	AdvNegoSeviceInfo
-	Tracer       trace.Tracer
-	PrefetchRows int
-	Failover     int
-	RetryTime    int
-	Lob          int
+	Tracer                     trace.Tracer
+	PrefetchRows               int
+	Failover                   int
+	RetryTime                  int
+	Lob                        int
+	DisableUrgentDataTransport uint16
 }
 
 func extractServers(connStr string) ([]ServerAddr, error) {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -396,7 +396,7 @@ func (session *Session) BreakConnection(discardRemaining bool) (PacketInterface,
 			return nil, err
 		}
 	}
-	return session.readPacket()
+	return nil, errors.New("connection break")
 	//session.ResetBuffer()
 	//if done {
 	//	err = session.writePacket(newMarkerPacket(2, session.Context))

--- a/v2/network/session_ctx.go
+++ b/v2/network/session_ctx.go
@@ -43,7 +43,7 @@ func NewSessionContext(connOption *ConnectionOption) *SessionContext {
 		TransportDataUnit: connOption.TransportDataUnitSize,
 		Version:           317,
 		LoVersion:         300,
-		Options:           1 | 1024 | 2048, /*1024 for urgent data transport*/
+		Options:           1 | 1024&^connOption.DisableUrgentDataTransport | 2048, /*1024 for urgent data transport*/
 		OurOne:            1,
 		ConnOption:        connOption,
 	}


### PR DESCRIPTION
Using `context.WithCancel` a call to the `cancel` func should interrupt the running operation (code snippet below).

```
ctx, cancel := context.WithCancel(context.Background())
		
go func () {
	fmt.Println(db.ExecContext(ctx, "begin for i in 1..120 loop dbms_lock.sleep(1); end loop; end;"))
}()

go func() {
	time.Sleep(1 * time.Second)
	cancel()
}()
```

To get it work i disable Urgent-Data-Transport (OOB) because `sendOOB` on windows is empty. Furthermore oracle-jdbc-driver and nodejs-thin-driver in my debug cases only (can) send marker packets. 

The main challenge is the race conidtion between the running operation (`read`) and another concurrent `read` from BreakConnection. That's why i simplify the code with returning an error instead of reading the ORA-01013 packet.