### PR TITLE
Interrupt a running operation

### DIFF
--- a/examples/cancel/main.go
+++ b/examples/cancel/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/sijms/go-ora/v2"
+)
+
+func main() {
+	var (
+		server string
+	)
+
+	flag.StringVar(&server, "server", "", "Server's URL, oracle://user:pass@server/service_name")
+	flag.Parse()
+
+	connStr := os.ExpandEnv(server)
+	if connStr == "" {
+		fmt.Println("Missing -server option")
+		//usage()
+		os.Exit(1)
+	}
+
+	fmt.Println("Connection string: ", connStr)
+	db, err := sql.Open("oracle", connStr)
+	if err != nil {
+		fmt.Println("Can't open database: ", err)
+		return
+	}
+
+	defer func() {
+		err = db.Close()
+		if err != nil {
+			fmt.Println("Can't close database: ", err)
+		}
+	}()
+
+	connectCtx, connectCancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer connectCancel()
+	conn, err := db.Conn(connectCtx)
+	if err != nil {
+		fmt.Println("Can't open connection: ", err)
+		return
+	}
+	defer func() {
+		err = conn.Close()
+		if err != nil {
+			fmt.Println("Can't close connection: ", conn)
+		}
+	}()
+
+	cancel(conn)
+	timeout(conn)
+
+	dbCancel(db)
+	dbTimeout(db)
+}
+
+func cancel(conn *sql.Conn) {
+	execCtx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		cancel()
+	}()
+
+	_, err := conn.ExecContext(execCtx, "begin DBMS_LOCK.sleep(60); end;")
+	if err != nil {
+		fmt.Println("Can't execute: ", err)
+		if !strings.Contains(err.Error(), "ORA-01013") {
+			panic(err)
+		}
+	}
+	if err == nil {
+		panic("should not happen")
+	}
+}
+
+func timeout(conn *sql.Conn) {
+	execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := conn.ExecContext(execCtx, "begin DBMS_LOCK.sleep(60); end;")
+	if err != nil {
+		fmt.Println("Can't execute: ", err)
+		if !strings.Contains(err.Error(), "ORA-01013") {
+			panic(err)
+		}
+	}
+	if err == nil {
+		panic("should not happen")
+	}
+}
+
+func dbCancel(db *sql.DB) {
+	execCtx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		cancel()
+	}()
+
+	_, err := db.ExecContext(execCtx, "begin DBMS_LOCK.sleep(60); end;")
+	if err != nil {
+		fmt.Println("Can't execute: ", err)
+		if !strings.Contains(err.Error(), "ORA-01013") {
+			panic(err)
+		}
+	}
+	if err == nil {
+		panic("should not happen")
+	}
+}
+
+func dbTimeout(db *sql.DB) {
+	execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := db.ExecContext(execCtx, "begin DBMS_LOCK.sleep(60); end;")
+	if err != nil {
+		fmt.Println("Can't execute: ", err)
+		if !strings.Contains(err.Error(), "ORA-01013") {
+			panic(err)
+		}
+	}
+	if err == nil {
+		panic("should not happen")
+	}
+}

--- a/v2/command.go
+++ b/v2/command.go
@@ -1258,7 +1258,8 @@ func (stmt *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (dr
 	}
 	tracer := stmt.connection.connOption.Tracer
 	tracer.Printf("Exec With Context:")
-	stmt.connection.session.StartContext(ctx)
+	done := stmt.connection.session.StartContext(ctx)
+	defer close(done)
 	defer stmt.connection.session.EndContext()
 	tracer.Printf("Exec:\n%s", stmt.text)
 	stmt.arrayBindCount = 0
@@ -2261,7 +2262,8 @@ func (stmt *Stmt) QueryContext(ctx context.Context, namedArgs []driver.NamedValu
 	tracer := stmt.connection.connOption.Tracer
 	tracer.Print("Query With Context:", stmt.text)
 
-	stmt.connection.session.StartContext(ctx)
+	done := stmt.connection.session.StartContext(ctx)
+	defer close(done)
 	defer stmt.connection.session.EndContext()
 	return stmt.Query_(namedArgs)
 }

--- a/v2/connection_string.go
+++ b/v2/connection_string.go
@@ -620,6 +620,8 @@ func newConnectionStringFromUrl(databaseUrl string) (*ConnectionString, error) {
 			if err != nil {
 				return nil, err
 			}
+		case "DISABLE URGENT DATA TRANSPORT":
+			ret.connOption.DisableUrgentDataTransport = 1024
 		default:
 			return nil, fmt.Errorf("unknown URL option: %s", key)
 			//else if tempVal == "IMPLICIT" || tempVal == "AUTO" {

--- a/v2/network/connect_option.go
+++ b/v2/network/connect_option.go
@@ -71,11 +71,12 @@ type ConnectionOption struct {
 	DatabaseInfo
 	SessionInfo
 	AdvNegoSeviceInfo
-	Tracer       trace.Tracer
-	PrefetchRows int
-	Failover     int
-	RetryTime    int
-	Lob          int
+	Tracer                     trace.Tracer
+	PrefetchRows               int
+	Failover                   int
+	RetryTime                  int
+	Lob                        int
+	DisableUrgentDataTransport uint16
 }
 
 func extractServers(connStr string) ([]ServerAddr, error) {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -396,7 +396,7 @@ func (session *Session) BreakConnection(discardRemaining bool) (PacketInterface,
 			return nil, err
 		}
 	}
-	return session.readPacket()
+	return nil, errors.New("connection break")
 	//session.ResetBuffer()
 	//if done {
 	//	err = session.writePacket(newMarkerPacket(2, session.Context))

--- a/v2/network/session_ctx.go
+++ b/v2/network/session_ctx.go
@@ -43,7 +43,7 @@ func NewSessionContext(connOption *ConnectionOption) *SessionContext {
 		TransportDataUnit: connOption.TransportDataUnitSize,
 		Version:           317,
 		LoVersion:         300,
-		Options:           1 | 1024 | 2048, /*1024 for urgent data transport*/
+		Options:           1 | 1024&^connOption.DisableUrgentDataTransport | 2048, /*1024 for urgent data transport*/
 		OurOne:            1,
 		ConnOption:        connOption,
 	}

--- a/v2/transaction.go
+++ b/v2/transaction.go
@@ -16,7 +16,8 @@ func (tx *Transaction) Commit() error {
 	}
 	tx.conn.autoCommit = true
 	tx.conn.session.ResetBuffer()
-	tx.conn.session.StartContext(tx.ctx)
+	done := tx.conn.session.StartContext(tx.ctx)
+	defer close(done)
 	defer tx.conn.session.EndContext()
 	return (&simpleObject{connection: tx.conn, operationID: 0xE}).exec()
 }
@@ -27,7 +28,8 @@ func (tx *Transaction) Rollback() error {
 	}
 	tx.conn.autoCommit = true
 	tx.conn.session.ResetBuffer()
-	tx.conn.session.StartContext(tx.ctx)
+	done := tx.conn.session.StartContext(tx.ctx)
+	defer close(done)
 	defer tx.conn.session.EndContext()
 	return (&simpleObject{connection: tx.conn, operationID: 0xF}).exec()
 }


### PR DESCRIPTION
Using `context.WithCancel` a call to the `cancel` func should interrupt the running operation (code snippet below).

```
ctx, cancel := context.WithCancel(context.Background())
		
go func () {
	fmt.Println(db.ExecContext(ctx, "begin for i in 1..120 loop dbms_lock.sleep(1); end loop; end;"))
}()

go func() {
	time.Sleep(1 * time.Second)
	cancel()
}()
```

To get it work i disable Urgent-Data-Transport (OOB) because `sendOOB` on windows is empty. Furthermore oracle-jdbc-driver and nodejs-thin-driver in my debug cases only (can) send marker packets. 

The main challenge is the race conidtion between the running operation (`read`) and another concurrent `read` from `BreakConnection`. That's why i simplify the code with returning an error instead of reading the ORA-01013 packet.
