### PR TITLE
fix alter session set_clause

### DIFF
--- a/v2/driver.go
+++ b/v2/driver.go
@@ -72,7 +72,7 @@ func (driver *OracleDriver) init(conn *Connection) error {
 	// update session parameters
 	var err error
 	for key, value := range driver.sessionParam {
-		_, err = conn.Exec(fmt.Sprintf("alter session set %s='%s'", key, value))
+		_, err = conn.Exec(fmt.Sprintf("alter session set %s=%s", key, value))
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func DelSessionParam(db *sql.DB, key string) {
 	}
 }
 func AddSessionParam(db *sql.DB, key, value string) error {
-	_, err := db.Exec(fmt.Sprintf("alter session set %s='%s'", key, value))
+	_, err := db.Exec(fmt.Sprintf("alter session set %s=%s", key, value))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If  `go_ora.AddSessionParam(db, "CURRENT_SCHEMA", schema)` used, single quotes at `"alter session set %s='%s'"` raises ORA-02421: missing or invalid schema authorization identifier.

I think the caller should do escaping (add quotes) if necessary.

```
go_ora.AddSessionParam(db, "CURRENT_SCHEMA", schema)
go_ora.AddSessionParam(db, "nls_date_format", "'DD-MON-YYYY HH24:MI:SS'")
```