### PR TITLE
Fixed: utils.refineSqlText - Removed the increment from the form index

### DIFF
--- a/v2/utils.go
+++ b/v2/utils.go
@@ -59,7 +59,6 @@ func refineSqlText(text string) string {
 		switch ch {
 		case '\\':
 			// bypass next character
-			index++
 			continue
 		case '/':
 			if index+1 < length && text[index+1] == '*' {


### PR DESCRIPTION
Fixed: utils.refineSqlText - Removed the increment from the form index if the character is '\\', as it is removing a single quote when the query has a concatenation of texts with a slash, leaving the skip equal to true for the rest of the query.

The error caused when the query has parameters.
                             
Example: SELECT ID, DESCRIPTION||'\'||DESCRIPTION FROM FAB_PROCESSO WHERE ID = :ID
                             
Error: ORA-01008: not all variables bound