### PR TITLE
Add authentication for SYSDG and other roles

### DIFF
--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -16,6 +16,11 @@ const (
 	NONE    DBAPrivilege = 0
 	SYSDBA  DBAPrivilege = 0x20
 	SYSOPER DBAPrivilege = 0x40
+	SYSASM  DBAPrivilege = 0x00400000
+	SYSBKP  DBAPrivilege = 0x01000000
+	SYSDGD  DBAPrivilege = 0x02000000
+	SYSKMT  DBAPrivilege = 0x04000000
+	SYSRAC  DBAPrivilege = 0x08000000
 )
 
 type AuthType int
@@ -159,6 +164,16 @@ func DBAPrivilegeFromString(s string) DBAPrivilege {
 		return SYSDBA
 	} else if S == "SYSOPER" {
 		return SYSOPER
+	} else if S == "SYSASM" {
+		return SYSASM
+	} else if S == "SYSBKP" {
+		return SYSBKP
+	} else if S == "SYSDGD" {
+		return SYSDGD
+	} else if S == "SYSKMT" {
+		return SYSKMT
+	} else if S == "SYSRAC" {
+		return SYSRAC
 	} else {
 		return NONE
 	}

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -34,6 +34,11 @@ const (
 	NoNewPass   LogonMode = 0x1
 	SysDba      LogonMode = 0x20
 	SysOper     LogonMode = 0x40
+	SysAsm      LogonMode = 0x00400000
+	SysBkp      LogonMode = 0x01000000
+	SysDgd      LogonMode = 0x02000000
+	SysKmt      LogonMode = 0x04000000
+	SysRac      LogonMode = 0x08000000
 	UserAndPass LogonMode = 0x100
 	//WithNewPass LogonMode = 0x2
 	//PROXY       LogonMode = 0x400
@@ -406,6 +411,16 @@ func (conn *Connection) OpenWithContext(ctx context.Context) error {
 		conn.LogonMode |= SysDba
 	case configurations.SYSOPER:
 		conn.LogonMode |= SysOper
+	case configurations.SYSASM:
+		conn.LogonMode |= SysAsm
+	case configurations.SYSBKP:
+		conn.LogonMode |= SysBkp
+	case configurations.SYSDGD:
+		conn.LogonMode |= SysDgd
+	case configurations.SYSKMT:
+		conn.LogonMode |= SysKmt
+	case configurations.SYSRAC:
+		conn.LogonMode |= SysRac
 	default:
 		conn.LogonMode = 0
 	}


### PR DESCRIPTION
I needed ability to use SYSDG role to monitor database in MOUNTED state using https://github.com/iamseth/oracledb_exporter.
I'm not advanced Golang programmer - but this simple change works for me and does not break ability to connect to older versions (tested this with 11gR2 which does not support SYSDB privilege and with 12.x, 18.x and 19.x - which works in such mode)