### PR TITLE
Fix problem caused by not handling error

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -7,8 +7,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/configurations"
-	"github.com/sijms/go-ora/v2/trace"
 	"os"
 	"reflect"
 	"regexp"
@@ -17,8 +15,10 @@ import (
 	"time"
 
 	"github.com/sijms/go-ora/v2/advanced_nego"
+	"github.com/sijms/go-ora/v2/configurations"
 	"github.com/sijms/go-ora/v2/converters"
 	"github.com/sijms/go-ora/v2/network"
+	"github.com/sijms/go-ora/v2/trace"
 )
 
 type ConnectionState int
@@ -776,6 +776,9 @@ func (conn *Connection) getServerNetworkInformation(code uint8) error {
 			return err
 		}
 		conn.transactionID, err = session.GetClr()
+		if err != nil {
+			return err
+		}
 		if len(conn.transactionID) > length {
 			conn.transactionID = conn.transactionID[:length]
 		}
@@ -1031,6 +1034,9 @@ func (conn *Connection) BulkInsert(sqlText string, rowNum int, columns ...[]driv
 	session := conn.session
 	session.ResetBuffer()
 	err := stmt.basicWrite(stmt.getExeOption(), stmt.parse, stmt.define)
+	if err != nil {
+		return nil, err
+	}
 	for x := 0; x < rowNum; x++ {
 		for idx, col := range columns {
 			stmt.Pars[idx].Value = col[x]
@@ -1080,10 +1086,10 @@ func (conn *Connection) QueryRowContext(ctx context.Context, query string, args 
 	stmt := NewStmt(query, conn)
 	stmt.autoClose = true
 	rows, err := stmt.QueryContext(ctx, args)
-	dataSet := rows.(*DataSet)
 	if err != nil {
 		return &DataSet{lasterr: err}
 	}
+	dataSet := rows.(*DataSet)
 	dataSet.Next_()
 	return dataSet
 }
@@ -1166,6 +1172,9 @@ func (conn *Connection) readMsg(msgCode uint8) error {
 			return err
 		}
 		size, err = session.GetInt(2, true, true)
+		if err != nil {
+			return err
+		}
 		for x := 0; x < size; x++ {
 			_, val, num, err := session.GetKeyVal()
 			if err != nil {

--- a/v2/data_set.go
+++ b/v2/data_set.go
@@ -369,6 +369,9 @@ func (dataSet *DataSet) Next(dest []driver.Value) error {
 
 // Columns return a string array that represent columns names
 func (dataSet *DataSet) Columns() []string {
+	if dataSet == nil {
+		return nil
+	}
 	if len(*dataSet.cols) == 0 {
 		return nil
 	}


### PR DESCRIPTION
During usage, we encountered a Panic error:
```
error: interface conversion: driver.Rows is nil, not *go_ora.DataSet
runtime.panicdottypeE
    /usr/local/go/src/runtime/iface.go:262
runtime.panicdottypeI
    /usr/local/go/src/runtime/iface.go:272
github.com/sijms/go-ora/v2.(*Connection).QueryRowContext
    /go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.19/connection.go:1083
github.com/sijms/go-ora/v2.(*Connection).getDBTimeZone
    /go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.19/connection.go:509
github.com/sijms/go-ora/v2.(*Connection).dataTypeNegotiation
    /go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.19/connection.go:1289
```
After investigation, it seems that the issue was caused by not handling the error in the code. 
Therefore, submitted this PR to resolve the problem and also fixed #564 
