### PR TITLE
fix redirect missing key parameters

### DIFF
--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -129,6 +129,48 @@ func (info *DatabaseInfo) UpdateDatabaseInfo(connStr string) error {
 	}
 	return nil
 }
+
+func (info *DatabaseInfo) UpdateDatabaseInfoForRedirect(redirectAddr string, reconnectData string) error {
+	redirectAddr = strings.ReplaceAll(redirectAddr, "\r", "")
+	redirectAddr = strings.ReplaceAll(redirectAddr, "\n", "")
+	reconnectData = strings.ReplaceAll(reconnectData, "\r", "")
+	reconnectData = strings.ReplaceAll(reconnectData, "\n", "")
+	var err error
+	info.Servers, err = ExtractServers(redirectAddr)
+	if err != nil {
+		return err
+	}
+	if len(info.Servers) == 0 {
+		return errors.New("no address passed in connection string")
+	}
+	r, err := regexp.Compile(`(?i)\(\s*SERVICE_NAME\s*=\s*([\w.-]+)\s*\)`)
+	if err != nil {
+		return err
+	}
+	match := r.FindStringSubmatch(reconnectData)
+	if len(match) > 1 {
+		info.ServiceName = match[1]
+	}
+	r, err = regexp.Compile(`(?i)\(\s*SID\s*=\s*([\w.-]+)\s*\)`)
+	if err != nil {
+		return err
+	}
+	match = r.FindStringSubmatch(reconnectData)
+	if len(match) > 1 {
+		info.SID = match[1]
+	}
+	r, err = regexp.Compile(`(?i)\(\s*INSTANCE_NAME\s*=\s*([\w.-]+)\s*\)`)
+	if err != nil {
+		return err
+	}
+	match = r.FindStringSubmatch(reconnectData)
+	if len(match) > 1 {
+		info.InstanceName = match[1]
+	}
+	info.connStr = ""
+	return nil
+}
+
 func (info *DatabaseInfo) AddServer(server ServerAddr) {
 	for i := 0; i < len(info.Servers); i++ {
 		if server.IsEqual(&info.Servers[i]) {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -575,15 +575,11 @@ func (session *Session) Connect(ctx context.Context) error {
 	}
 	if redirectPacket, ok := pck.(*RedirectPacket); ok {
 		session.tracer.Print("Redirect")
-		//connOption.connData = redirectPacket.reconnectData
-		servers, err := configurations.ExtractServers(redirectPacket.redirectAddr)
+		err = session.Context.connConfig.UpdateDatabaseInfoForRedirect(redirectPacket.redirectAddr, redirectPacket.reconnectData)
 		if err != nil {
 			return err
 		}
-		for _, srv := range servers {
-			connOption.AddServer(srv)
-		}
-		host = connOption.GetActiveServer(true)
+		session.Context.connConfig.ResetServerIndex()
 		return session.Connect(ctx)
 	}
 	if refusePacket, ok := pck.(*RefusePacket); ok {


### PR DESCRIPTION
When a redirect return is received, the local address list is refreshed based on the address list returned by the server, and the parameters returned by the server are parsed and appended to the next connection.
This will solve the issue that I created [#583](https://github.com/sijms/go-ora/issues/583)