### PR TITLE
inf in number type

### DIFF
--- a/v2/number.go
+++ b/v2/number.go
@@ -174,6 +174,12 @@ func (num *Number) decode() (strNum string, exp int, negative bool, err error) {
 	} else {
 		exp = int(num.data[0]&0x7F) - 64
 	}
+
+	if _isPosInf(num.data) || _isNegInf(num.data) {
+		strNum = "Infinity"
+		return
+	}
+
 	buf := num.data[1:]
 	if negative && buf[len(buf)-1] == 0x66 {
 		buf = buf[:len(buf)-1]
@@ -190,6 +196,15 @@ func (num *Number) decode() (strNum string, exp int, negative bool, err error) {
 	exp = exp*2 - len(output)
 	strNum = string(output)
 	return
+}
+
+func _isNegInf(b []byte) bool {
+	return b[0] == 0 && len(b) == 1
+}
+
+func _isPosInf(b []byte) bool {
+	// -1 =255
+	return len(b) == 2 && b[0] == 255 && b[1] == 101
 }
 
 func (num *Number) Int64() (int64, error) {


### PR DESCRIPTION
in my testing oracle I have number column and extra large numbers

```
     ID_OP      PRICE      OASUM
---------- ---------- ----------
  37840227          ~         -~
  ```

I found answer in docs.

https://docs.oracle.com/cd/B13789_01/server.101/b10759/sql_elements004.htm

```
If a positive NUMBER value is extremely large and cannot be represented in the specified format, 
then the infinity sign (~) replaces the value. 
Likewise, if a negative NUMBER value is extremely small and 
cannot be represented by the specified format, then the negative infinity sign replaces the value (-~).
```

https://github.com/sijms/go-ora/issues/579 related issue