### PR TITLE
Restore SYSDG and other administrative privileges

### DIFF
--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -13,9 +13,14 @@ const defaultPort int = 1521
 type DBAPrivilege int
 
 const (
-	NONE    DBAPrivilege = 0
-	SYSDBA  DBAPrivilege = 0x20
-	SYSOPER DBAPrivilege = 0x40
+	NONE      DBAPrivilege = 0
+	SYSDBA    DBAPrivilege = 0x20
+	SYSOPER   DBAPrivilege = 0x40
+	SYSASM    DBAPrivilege = 0x00400000
+	SYSBACKUP DBAPrivilege = 0x01000000
+	SYSDG     DBAPrivilege = 0x02000000
+	SYSKM     DBAPrivilege = 0x04000000
+	SYSRAC    DBAPrivilege = 0x08000000
 )
 
 type AuthType int
@@ -213,12 +218,22 @@ func (info *DatabaseInfo) GetActiveServer(jump bool) *ServerAddr {
 }
 
 func DBAPrivilegeFromString(s string) DBAPrivilege {
-	S := strings.ToUpper(s)
-	if S == "SYSDBA" {
+	switch strings.ToUpper(s) {
+	case "SYSDBA":
 		return SYSDBA
-	}
-	if S == "SYSOPER" {
+	case "SYSOPER":
 		return SYSOPER
+	case "SYSASM":
+		return SYSASM
+	case "SYSBACKUP":
+		return SYSBACKUP
+	case "SYSDG":
+		return SYSDG
+	case "SYSKM":
+		return SYSKM
+	case "SYSRAC":
+		return SYSRAC
+	default:
+		return NONE
 	}
-	return NONE
 }

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -37,6 +37,11 @@ const (
 	NoNewPass   LogonMode = 0x1
 	SysDba      LogonMode = 0x20
 	SysOper     LogonMode = 0x40
+	SysAsm      LogonMode = 0x00400000
+	SysBackup   LogonMode = 0x01000000
+	SysDg       LogonMode = 0x02000000
+	SysKm       LogonMode = 0x04000000
+	SysRac      LogonMode = 0x08000000
 	UserAndPass LogonMode = 0x100
 	// WithNewPass LogonMode = 0x2
 	// PROXY       LogonMode = 0x400
@@ -402,6 +407,16 @@ func (conn *Connection) OpenWithContext(ctx context.Context) error {
 		conn.LogonMode |= SysDba
 	case configurations.SYSOPER:
 		conn.LogonMode |= SysOper
+	case configurations.SYSASM:
+		conn.LogonMode |= SysAsm
+	case configurations.SYSBACKUP:
+		conn.LogonMode |= SysBackup
+	case configurations.SYSDG:
+		conn.LogonMode |= SysDg
+	case configurations.SYSKM:
+		conn.LogonMode |= SysKm
+	case configurations.SYSRAC:
+		conn.LogonMode |= SysRac
 	default:
 		conn.LogonMode = 0
 	}


### PR DESCRIPTION
#563 added support for SYSDG and other Oracle administrative privileges.  These changes got inadvertently clobbered by #591.  This PR brings them back, in addition to correcting privileges SYSBACKUP, SYSDG, and SYSKM to match their string names rather than the oci.h abbreviations.  So we recognize `/ AS SYSBACKUP` to match https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-privilege-and-role-authorization.html, rather than `/ AS SYSBKP`.