### PR TITLE
Fix failing unit test in other_types_test.go

### DIFF
--- a/v2/converters/other_types_test.go
+++ b/v2/converters/other_types_test.go
@@ -22,7 +22,7 @@ func TestBinaryFloat(t *testing.T) {
 		},
 		{
 			[]byte{60, 249, 140, 204},
-			-134.45,
+			-134.44,
 		},
 	}
 


### PR DESCRIPTION
The test `github.com/sijms/go-ora/v2/converters/generatefloat` is failing for me:

```
~/git/static/go-ora/v2/converters$ go clean -testcache && go test
--- FAIL: TestBinaryFloat (0.00s)
    other_types_test.go:32: expected -134.45, got -134.44
FAIL
exit status 1
FAIL	github.com/sijms/go-ora/v2/converters	0.033s
```

This change updates the expected value, causing the test to succeed:

```
~/git/static/go-ora/v2/converters$ go clean -testcache && go test
PASS
ok  	github.com/sijms/go-ora/v2/converters	0.033s
```