### PR TITLE
Add cgo dependency to avoid go fmt failures

### DIFF
--- a/examples/kerberos/main.go
+++ b/examples/kerberos/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"C" // Import cgo to avoid project-wide go fmt failures.
 	"database/sql"
 	"flag"
 	"fmt"


### PR DESCRIPTION
The `PR Check` GitHub Action runs `go fmt` and then builds and unit tests.  But the `go fmt` run is currently failing with the error message:

```
package github.com/sijms/go-ora/examples/kerberos: C++ source files not allowed when not using cgo or SWIG: kerberos.cpp
```

This change adds a dummy cgo dependency in the example to make this error go away and unblock the PR checks.  The PR checks will continue failing for now, however, because some unit tests themselves are failing.