### PR TITLE
fix "overflows int" on 32bit arch

### DIFF
--- a/v2/converters/other_types.go
+++ b/v2/converters/other_types.go
@@ -78,7 +78,7 @@ func ConvertIntervalYM_DTY(val []byte) string {
 	   months + 60
 	*/
 	uyears := binary.BigEndian.Uint32(val)
-	years := int(uyears) - 2147483648
+	years := int64(uyears) - 2147483648
 	if years >= 0 {
 		months := val[4] - 60
 		return fmt.Sprintf("+%02d-%02d", years, months)
@@ -99,13 +99,13 @@ func ConvertIntervalDS_DTY(val []byte) string {
 	   nanoseconds
 	*/
 	udays := binary.BigEndian.Uint32(val)
-	days := int(udays) - 2147483648
+	days := int64(udays) - 2147483648
 	if days >= 0 {
 		hours := val[4] - 60
 		mins := val[5] - 60
 		secs := val[6] - 60
 		uns := binary.BigEndian.Uint32(val[7:])
-		ns := (int(uns) - 2147483648) / 1000
+		ns := (int64(uns) - 2147483648) / 1000
 		return fmt.Sprintf("+%02d %02d:%02d:%02d.%06d", days, hours, mins, secs, ns)
 	}
 	days = -days
@@ -113,6 +113,6 @@ func ConvertIntervalDS_DTY(val []byte) string {
 	mins := 60 - val[5]
 	secs := 60 - val[6]
 	uns := binary.BigEndian.Uint32(val[7:])
-	ns := -(int(uns) - 2147483648) / 1000
+	ns := -(int64(uns) - 2147483648) / 1000
 	return fmt.Sprintf("-%02d %02d:%02d:%02d.%06d", days, hours, mins, secs, ns)
 }


### PR DESCRIPTION
Fixes: #603

Fixes the following problem when compiling for 32bit arch

```
Building linux/386
# github.com/sijms/go-ora/v2/converters
/Users/ilyam/go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.21/converters/other_types.go:81:25: 2147483648 (untyped int constant) overflows int
/Users/ilyam/go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.21/converters/other_types.go:102:23: 2147483648 (untyped int constant) overflows int
/Users/ilyam/go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.21/converters/other_types.go:108:21: 2147483648 (untyped int constant) overflows int
/Users/ilyam/go/pkg/mod/github.com/sijms/go-ora/v2@v2.8.21/converters/other_types.go:116:21: 2147483648 (untyped int constant) overflows int
```