### PR TITLE
Reimplement "Add ability to auth based on tls.Config" (e2a9f1131a4)

### DIFF
--- a/v2/configurations/session_info.go
+++ b/v2/configurations/session_info.go
@@ -2,6 +2,7 @@ package configurations
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strings"
@@ -22,6 +23,7 @@ type SessionInfo struct {
 	Protocol              string
 	SSL                   bool
 	SSLVerify             bool
+	TLSConfig             *tls.Config
 	Dialer                DialerContext
 }
 

--- a/v2/connection.go
+++ b/v2/connection.go
@@ -2,6 +2,7 @@ package go_ora
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/binary"
@@ -112,6 +113,7 @@ type OracleConnector struct {
 	drv           *OracleDriver
 	connectString string
 	dialer        configurations.DialerContext
+	tlsConfig     *tls.Config
 }
 
 func NewConnector(connString string) driver.Connector {
@@ -138,6 +140,9 @@ func (connector *OracleConnector) Connect(ctx context.Context) (driver.Conn, err
 	if conn.connOption.Dialer == nil {
 		conn.connOption.Dialer = connector.dialer
 	}
+	if conn.connOption.TLSConfig == nil {
+		conn.connOption.TLSConfig = connector.tlsConfig
+	}
 	err = conn.OpenWithContext(ctx)
 	if err != nil {
 		return nil, err
@@ -155,6 +160,10 @@ func (connector *OracleConnector) Driver() driver.Driver {
 
 func (connector *OracleConnector) Dialer(dialer configurations.DialerContext) {
 	connector.dialer = dialer
+}
+
+func (connector *OracleConnector) WithTLSConfig(config *tls.Config) {
+	connector.tlsConfig = config
 }
 
 // Open return a new open connection


### PR DESCRIPTION
`master` branch was synced with upstream.

The updated `.WithTLSConfig()` saw large changes as upstream code was significantly restructured. I've tested the respective Teleport functionality and it continues to work after this.