### PR TITLE
Fix decode Infinity number. Exp value always must be 0.

### DIFF
--- a/v2/number.go
+++ b/v2/number.go
@@ -180,6 +180,7 @@ func (num *Number) decode() (strNum string, exp int, negative bool, err error) {
 
 	if _isPosInf(num.data) || _isNegInf(num.data) {
 		strNum = "Infinity"
+		exp = 0
 		return
 	}
 


### PR DESCRIPTION
In some cases exp value is not 0 which leads to incorrect decoding. 
<img width="699" alt="image" src="https://github.com/user-attachments/assets/883191f5-cc47-40d8-baaf-de7575f95f61">

