### PR TITLE
When compress is true, 'size' may be a value greater than 8 in some cases

### DIFF
--- a/network/session.go
+++ b/network/session.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1029,6 +1030,10 @@ func (session *Session) GetInt64(size int, compress bool, bigEndian bool) (int64
 	}
 	if size == 0 {
 		return 0, nil
+	} else if size > 8 {
+		// compress is true
+		// size = int(rb[0]) may be > 8
+		return 0, errors.New("invalid size for GetInt64: " + strconv.Itoa(size))
 	}
 	rb, err := session.read(size)
 	if err != nil {

--- a/network/session.go
+++ b/network/session.go
@@ -1031,8 +1031,7 @@ func (session *Session) GetInt64(size int, compress bool, bigEndian bool) (int64
 	if size == 0 {
 		return 0, nil
 	} else if size > 8 {
-		// compress is true
-		// size = int(rb[0]) may be > 8
+		// When compress is true, "size" may be a value greater than 8 in some cases
 		return 0, errors.New("invalid size for GetInt64: " + strconv.Itoa(size))
 	}
 	rb, err := session.read(size)


### PR DESCRIPTION
In some cases, the service may panic.
In Sijms/go ora v2.8.18, the call stack is as follows:

```
runtime error: slice bounds out of range [-18:]

/usr/local/go/src/runtime/panic.go:154 (0xbcc3fb)
./vendor/github.com/sijms/go-ora/v2/network/session.go:1594 (0x1239f54)
./vendor/github.com/siims/go-ora/v2/network/session.go:1610 (0x12f453e)
./vendor/github,com/sijms/go-ora/v2/parameter.go:250 (0x12f4547)
./vendor/github.com/sijms/go-ora/v2/command.go:987(0x12d942e)
./vendor/github.com/sijms/go-ora/v2/command.go:2362 (0x12e0f56)
./vendor/github.com/sijms/go-ora/v2/command.go:2255 (0x12e08d5)
./vendor/github.com/sijms/go-ora/v2/command.go:2330 (0x12e0c36)
./vendor/github.com/sijms/go-ora/v2/connection.go:1104 (0x12e7754)
/usr/local/go/src/database/sql/ctxutil.go:48 (0xffb1f6)
/usr/local/go/src/database/sql/sgl.ga:1776(0x1004098)
/usr/local/go/src/database/sql/sql.g0:3530(0x100bf21)
/usr/local/go/src/database/sql/sgl.go:1771(0x10038bd)
/usr/local/go/src/database/sql/sql.go:1754 (0x100365b)
/usr/local/go/src/database/sql/sql.g0:1732 (0x100344e)
/usr/local/go/src/database/sql/sql.go:1566 (0x1001be1)
/usr/local/go/src/database/sql/sql.g0:1731(0x1003364)
./vendor/gorm.io/gorm/callbacks/row.go:16(0x109e4db)
./vendor/gorm.io/gorm/callbacks.go:130(0x105d8ab)
./vendor/gorm.io/gorm/finisher_api.go:516 (0x10684d1)
```