### PR TITLE
Add basic support of TNS Names files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ connStr := go_ora.BuildJDBC("username", "password", "JDBC string", urlOptions)
 conn, err := sql.Open("oracle", connStr)
 // check for error
 ```
+
+* ### Connect using TNS names file
+
+To use connection data from a TNS names file, you should specify it explicitly via url options
+
+```golang
+urlOptions := map[string] string {
+	"tns names": "path to a TNS names file (not a folder, a file!)",
+}
+connStr := go_ora.BuildUrl("server", port, "service_name", "username", "password", urlOptions)
+```
+
+or place your file to the `${TNS_ADMIN}/` folder (in this case TNS names file **must be named** `tnsnames.ora`).
+
+Another example of a connection URL which specifies TNS names file explicitly:
+
+`oracle://myhost:1523/db?TNS NAMES=escaped/path/to/your/tnsnames.ora`.
+
+Only a small subset of features/properties of TNS names files is supported - in case you specify something `go-ora`
+doesn't support at the moment, `go-ora` will fail. Don't expect failover, load balancing or other such features to be working.
+
+TNS names file format description can be found [here](https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-47DAB4DF-1D35-46E5-B227-339FF912E058).
+
 * ### SSL Connection
 to use ssl connection you should pass required url options.
 ```golang

--- a/v2/configurations/connect_config.go
+++ b/v2/configurations/connect_config.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sijms/go-ora/v2/tns"
 )
 
 type LobFetch int
@@ -116,19 +118,9 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 		config.DBAPrivilege = SYSDBA
 	}
 
-	host, p, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		return nil, err
-	}
-	if len(host) > 0 {
-		tempAddr := ServerAddr{Addr: host, Port: defaultPort}
-		tempAddr.Port, err = strconv.Atoi(p)
-		if err != nil {
-			tempAddr.Port = defaultPort
-		}
-		config.Servers = append(config.Servers, tempAddr)
-	}
-	config.ServiceName = strings.Trim(u.Path, "/")
+	var servers []ServerAddr
+	var serviceName, tnsNamesExplicitPath string
+
 	for key, val := range q {
 		switch strings.ToUpper(key) {
 		case "CID":
@@ -139,6 +131,7 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 				return nil, err
 			}
 		case "SERVER":
+			// These values are to be used as is - TNS names resolution won't be applied to them.
 			for _, srv := range val {
 				srv = strings.TrimSpace(srv)
 				if srv != "" {
@@ -153,11 +146,12 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 							tempAddr.Port = defaultPort
 						}
 					}
-					config.Servers = append(config.Servers, tempAddr)
+					servers = append(servers, tempAddr)
 				}
 			}
 		case "SERVICE NAME":
-			config.ServiceName = val[0]
+			// Override service name
+			serviceName = val[0]
 		case "SID":
 			config.SID = val[0]
 		case "INSTANCE NAME":
@@ -188,7 +182,6 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 			fallthrough
 		case "OS PASSWORD HASH":
 			config.ClientInfo.OSPassword = val[0]
-
 		case "DOMAIN":
 			config.DomainName = val[0]
 		case "AUTH SERV":
@@ -314,6 +307,8 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 			config.ClientInfo.ProgramName = val[0]
 		case "SERVER LOCATION":
 			config.DatabaseInfo.Location = val[0]
+		case "TNS NAMES":
+			tnsNamesExplicitPath = val[0]
 		default:
 			return nil, fmt.Errorf("unknown URL option: %s", key)
 			// else if tempVal == "IMPLICIT" || tempVal == "AUTO" {
@@ -328,7 +323,7 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 			// case "INC POOL SIZE":
 			//	ret.IncrPoolSize, err = strconv.Atoi(val[0])
 			//	if err != nil {
-			//		return nil, errors.New("INC POOL SIZE value must be an integer")
+			//		return nil, errors.NewserviceName("INC POOL SIZE value must be an integer")
 			//	}
 			// case "DECR POOL SIZE":
 			//	ret.DecrPoolSize, err = strconv.Atoi(val[0])
@@ -397,13 +392,81 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 			//	ret.ProxyPassword = val[0]
 		}
 	}
+
+	if serviceName != "" {
+		// We have an explicitly specified service name => use it
+		config.ServiceName = serviceName
+	}
+
+	// Generate a net service name. It will be a path part of the connection URL
+	// or a full "<host>:<port>/<path>" if "<host>:<port>" is present.
+	urlPath := strings.Trim(u.Path, "/")
+	netServiceName := urlPath
+	if u.Host != "" {
+		// Prepend "<host>:<port>/" as they've been specified
+		netServiceName = u.Host + "/" + netServiceName
+	}
+
+	// Split host and port
+	urlHost, strUrlPort, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split '<host>:<port>' part of the connection URL: %w", err)
+	}
+	urlPort := defaultPort
+	if urlPort, err = strconv.Atoi(strUrlPort); err != nil {
+		urlPort = defaultPort
+	}
+
+	// Resolve TNS names filepath
+	tnsNamesPath, err := tns.ResolveFilepath(tnsNamesExplicitPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve TNS names filepath: %w", err)
+	}
+
+	// Set servers
+	if len(servers) > 0 {
+		// We have explicitly specified server addresses => use them
+		config.Servers = servers
+	} else if tnsNamesPath != "" {
+		// We have a non-empty path to a TNS names file => load connection data from it
+		resolvedServiceName, resolvedServers, err := getConnParamsFromTNS(tnsNamesPath, netServiceName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get connection params from TNS Names file: %w", err)
+		}
+		if len(resolvedServers) > 0 {
+			// Set servers if we've found at least one of them in TNS names file
+			config.Servers = resolvedServers
+		}
+		if config.ServiceName == "" && resolvedServiceName != "" {
+			// If service name has not been specified explicitly and we've resolved a service name via TNS names,
+			// use the resolved service name
+			config.ServiceName = resolvedServiceName
+		}
+	}
+
+	if len(config.Servers) == 0 {
+		// We still don't have information about servers to connect to - try to use server address from the connection URL
+		if len(urlHost) > 0 {
+			config.Servers = []ServerAddr{{Addr: urlHost, Port: urlPort}}
+		}
+	}
+
+	// Check that we have at least one server to connect to
 	if len(config.Servers) == 0 {
 		return nil, errors.New("empty connection servers")
 	}
+
+	if config.ServiceName == "" {
+		// We still don't have information about a service name => use a path part of the connection URL
+		config.ServiceName = urlPath
+	}
+
 	if len(walletPath) > 0 {
+		// Work with Oracle wallet
 		if len(config.ServiceName) == 0 {
 			return nil, errors.New("you should specify server/service if you will use wallet")
 		}
+
 		if _, err = os.Stat(path.Join(walletPath, "ewallet.p12")); err == nil && len(walletPass) > 0 {
 			fileData, err := os.ReadFile(path.Join(walletPath, "ewallet.p12"))
 			if err != nil {
@@ -422,20 +485,30 @@ func ParseConfig(dsn string) (*ConnectionConfig, error) {
 		}
 
 		if len(config.UserID) > 0 {
+			// We have explicitly specified a user => we need to use it to find creds in the wallet
 			if len(config.Password) == 0 {
-				serv := config.Servers[0]
-				cred, err := config.Wallet.getCredential(serv.Addr, serv.Port, config.ServiceName, config.UserID)
+				// Try to find a password in the wallet
+				creds, err := config.Wallet.getCredential(urlHost, urlPort, urlPath, config.UserID)
 				if err != nil {
 					return nil, err
 				}
-				if cred == nil {
-					return nil, errors.New(
-						fmt.Sprintf("cannot find credentials for server: %s:%d, service: %s,  username: %s",
-							serv.Addr, serv.Port, config.ServiceName, config.UserID))
+				if creds == nil {
+					return nil, fmt.Errorf(
+						"cannot find credentials for server: '%s:%d', service: '%s', username: '%s' in the wallet",
+						urlHost, urlPort, urlPath, config.UserID,
+					)
 				}
-				config.UserID = cred.username
-				config.Password = cred.password
+				config.UserID = creds.username
+				config.Password = creds.password
 			}
+		} else {
+			// We don't have an explicitly specified user => try to find creds in the wallet by DSN (net service name)
+			creds := config.Wallet.getCredentialByDsn(netServiceName)
+			if creds == nil {
+				return nil, fmt.Errorf("cannot find credentials for net service with name '%s' in the wallet", netServiceName)
+			}
+			config.UserID = creds.username
+			config.Password = creds.password
 		}
 	}
 	return config, config.validate()

--- a/v2/configurations/connect_config_tns.go
+++ b/v2/configurations/connect_config_tns.go
@@ -1,0 +1,258 @@
+package configurations
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sijms/go-ora/v2/tns"
+)
+
+// getConnParamsFromTNS gets connection parameters from TNS names file at the specified path by net service name.
+//
+// Net service name is an alias used in TNS names file as a key of actual connection parameters.
+func getConnParamsFromTNS(
+	tnsNamesPath,
+	netServiceName string,
+) (resolvedServiceName string, resolvedServers []ServerAddr, err error) {
+	// Load TNS names
+	tnsNames, err := loadTNSNames(tnsNamesPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to load TNS names file '%s': %w", tnsNamesPath, err)
+	}
+
+	// Find a connect descriptor among TNS names
+	connDesc := tnsNames.GetDescriptorForService(netServiceName)
+	if connDesc == nil {
+		// No connect descriptor has been found in TNS names file => exit
+		return "", nil, nil
+	}
+
+	// Found a connection descriptor in TNS names => use it
+	var desc *tns.Description
+	switch {
+	case len(connDesc.DescriptionList.Descriptions) > 1:
+		// We don't support multiple 'DESCRIPTION'-s at the moment
+		return "", nil, errors.New("multiple 'DESCRIPTION'-s in 'DESCRIPTION_LIST' are not supported")
+	case len(connDesc.DescriptionList.Descriptions) == 1:
+		desc = &connDesc.DescriptionList.Descriptions[0]
+	default:
+		desc = &connDesc.Description
+	}
+
+	// Validate TNS connect description
+	err = validateTNSConnDescription(desc)
+	if err != nil {
+		return "", nil, fmt.Errorf("'DESCRIPTION' is incorrect: %w", err)
+	}
+
+	// Collect server addresses
+	for _, addr := range desc.AddressList.Address {
+		resolvedServers = append(resolvedServers, ServerAddr{
+			Protocol: addr.Protocol,
+			Addr:     addr.Host,
+			Port:     addr.Port,
+		})
+	}
+	for _, addrList := range desc.AddressLists {
+		for _, addr := range addrList.Address {
+			resolvedServers = append(resolvedServers, ServerAddr{
+				Protocol: addr.Protocol,
+				Addr:     addr.Host,
+				Port:     addr.Port,
+			})
+		}
+	}
+
+	// All done!
+	return desc.ConnectData.ServiceName, resolvedServers, nil
+}
+
+// loadTNSNames loads a TNS names file at specified path.
+func loadTNSNames(path string) (*tns.TNS, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TNS names file: %w", err)
+	}
+	// Parse TNS names
+	tnsNames, err := tns.Parse(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TNS names file: %w", err)
+	}
+	return tnsNames, nil
+}
+
+// validateTNSConnDescription validates the specified TNS connection description for unsupported features.
+func validateTNSConnDescription(desc *tns.Description) error {
+	if desc.RetryCount != 0 {
+		return errors.New("'RETRY_COUNT' is not supported. Please remove it")
+	}
+	if desc.TransportConnectTimeout != 0 {
+		return errors.New("'TRANSPORT_CONNECT_TIMEOUT' is not supported. Please remove it")
+	}
+	if desc.ConnectTimeout != 0 {
+		return errors.New("'CONNECT_TIMEOUT' is not supported. Please remove it")
+	}
+	if desc.Compression != "" {
+		return errors.New("'COMPRESSION' is not supported. Please remove it")
+	}
+	if len(desc.CompressionLevels) > 0 {
+		return errors.New("'COMPRESSION_LEVELS' is not supported. Please remove it")
+	}
+	if desc.EncryptionClient != "" {
+		return errors.New("'ENCRYPTION_CLIENT' is not supported. Please remove it")
+	}
+	if desc.AuthenticationServices != "" {
+		return errors.New("'AUTHENTICATION_SERVICES' is not supported. Please remove it")
+	}
+	if len(desc.AddressList.Address) > 0 && len(desc.AddressLists) > 0 {
+		return errors.New("please specify either 'ADDRESS_LIST' or multiple 'ADDRESS'-es exactly under 'DESCRIPTION'")
+	}
+	err := validateTNSAddressList(&desc.AddressList)
+	if err != nil {
+		return fmt.Errorf("embedded address list 'ADDRESS' is incorrect: %w", err)
+	}
+	if c := len(desc.AddressLists); c > 1 {
+		return fmt.Errorf("a single 'ADDRESS_LIST' is expected, got %d of them", c)
+	}
+	for _, addrList := range desc.AddressLists {
+		err = validateTNSAddressList(&addrList)
+		if err != nil {
+			return fmt.Errorf("'ADDRESS_LIST' is incorrect: %w", err)
+		}
+	}
+	err = validateTNSConnectionData(&desc.ConnectData)
+	if err != nil {
+		return fmt.Errorf("'CONNECT_DATA' is incorrect: %w", err)
+	}
+	err = validateTNSConnSecurity(&desc.Security)
+	if err != nil {
+		return fmt.Errorf("'SECURITY' is incorrect: %w", err)
+	}
+	return nil
+}
+
+// validateTNSConnectionData validates the specified TNS connection data for unsupported features.
+func validateTNSConnectionData(connData *tns.ConnectData) error {
+	if connData.ColocationTag != "" {
+		return errors.New("'COLOCATION_TAG' is not supported. Please remove it")
+	}
+	if connData.ConnectionIdPrefix != "" {
+		return errors.New("'CONNECTION_ID_PREFIX' is not supported. Please remove it")
+	}
+	if connData.PoolConnectionClass != "" {
+		return errors.New("'POOL_CONNECTION_CLASS' is not supported. Please remove it")
+	}
+	if connData.PoolPurity != "" {
+		return errors.New("'POOL_PURITY' is not supported. Please remove it")
+	}
+	if connData.ShardingKey != "" {
+		return errors.New("'SHARDING_KEY' is not supported. Please remove it")
+	}
+	if connData.SuperShardingKey != "" {
+		return errors.New("'SUPER_SHARDING_KEY' is not supported. Please remove it")
+	}
+	if connData.TunnelServiceName != "" {
+		return errors.New("'TUNNEL_SERVICE_NAME' is not supported. Please remove it")
+	}
+	if connData.FailoverMode != "" {
+		return errors.New("'FAILOVER_MODE' is not supported. Please remove it")
+	}
+	if connData.GlobalName != "" {
+		return errors.New("'GLOBAL_NAME' is not supported. Please remove it")
+	}
+	if connData.Hs != "" {
+		return errors.New("'HS' is not supported. Please remove it")
+	}
+	if connData.InstanceName != "" {
+		return errors.New("'INSTANCE_NAME' is not supported. Please remove it")
+	}
+	if connData.RdbDatabase != "" {
+		return errors.New("'RDB_DATABASE' is not supported. Please remove it")
+	}
+	if connData.Server != "" {
+		return errors.New("'SERVER' is not supported. Please remove it")
+	}
+	if connData.Sid != "" {
+		return errors.New("'SID' is not supported. Please remove it")
+	}
+	return nil
+}
+
+// validateTNSConnSecurity validates the specified TNS connection security for unsupported features.
+func validateTNSConnSecurity(sec *tns.Security) error {
+	if sec.SslServerCertDN != "" {
+		return errors.New("'SSL_SERVER_CERT_DN' is not supported. Please remove it")
+	}
+	if sec.AuthenticationService != "" {
+		return errors.New("'AUTHENTICATION_SERVICE' is not supported. Please remove it")
+	}
+	if sec.IgnoreAnoEncryption {
+		return errors.New("'IGNORE_ANO_ENCRYPTION' is not supported. Please remove it")
+	}
+	if sec.Kerberos5CCName != "" {
+		return errors.New("'KERBEROS5_CC_NAME' is not supported. Please remove it")
+	}
+	if sec.SslServerDNMatch {
+		return errors.New("'SSL_SERVER_DN_MATCH' is not supported. Please remove it")
+	}
+	if sec.SslVersion != "" {
+		return errors.New("'SSL_VERSION' is not supported. Please remove it")
+	}
+	if sec.WalletLocation != "" {
+		return errors.New("'WALLET_LOCATION' is not supported. Please remove it")
+	}
+	return nil
+}
+
+// validateTNSAddressList validates the specified TNS Address List for unsupported features.
+func validateTNSAddressList(addrList *tns.AddressList) error {
+	if addrList.Enable != "" {
+		return errors.New("'ENABLE' is not supported. Please remove it")
+	}
+	if addrList.Failover != "" {
+		return errors.New("'FAILOVER' is not supported. Please remove it")
+	}
+	if addrList.LoadBalance != "" {
+		return errors.New("'LOAD_BALANCE' is not supported. Please remove it")
+	}
+	if addrList.SourceRoute != "" {
+		return errors.New("'SOURCE_ROUTE' is not supported. Please remove it")
+	}
+	if addrList.TypeOfService != "" {
+		return errors.New("'TYPE_OF_SERVICE' is not supported. Please remove it")
+	}
+	if addrList.RecvBufSize != 0 {
+		return errors.New("'RECV_BUF_SIZE' is not supported. Please remove it")
+	}
+	if addrList.Sdu != 0 {
+		return errors.New("'SDU' is not supported. Please remove it")
+	}
+	if addrList.SendBufSize != 0 {
+		return errors.New("'SEND_BUF_SIZE' is not supported. Please remove it")
+	}
+	for _, addr := range addrList.Address {
+		err := validateTNSAddress(&addr)
+		if err != nil {
+			return fmt.Errorf("'ADDRESS' is incorrect: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateTNSAddress validates the provided TNS Address for unsupported features.
+func validateTNSAddress(addr *tns.Address) error {
+	if addr.RecvBufSize != 0 {
+		return errors.New("'RECV_BUF_SIZE' is not supported. Please remove it")
+	}
+	if addr.SendBufSize != 0 {
+		return errors.New("'SEND_BUF_SIZE' is not supported. Please remove it")
+	}
+	if addr.HttpsProxyHost != "" {
+		return errors.New("'HTTPS_PROXY' is not supported. Please remove it")
+	}
+	if addr.HttpsProxyPort != 0 {
+		return errors.New("'HTTPS_PROXY_PORT' is not supported. Please remove it")
+	}
+	return nil
+}

--- a/v2/configurations/wallet.go
+++ b/v2/configurations/wallet.go
@@ -536,3 +536,13 @@ func (w *Wallet) getCredential(server string, port int, service, username string
 	}
 	return nil, nil
 }
+
+func (w *Wallet) getCredentialByDsn(dsn string) *WalletCredential {
+	for _, cred := range w.credentials {
+		if cred.dsn == dsn {
+			credential := cred
+			return &credential
+		}
+	}
+	return nil
+}

--- a/v2/connection_string.go
+++ b/v2/connection_string.go
@@ -16,7 +16,7 @@ import (
 // )
 
 // type DBAPrivilege int
-// 
+//
 // const (
 // 	NONE    DBAPrivilege = 0
 // 	SYSDBA  DBAPrivilege = 0x20

--- a/v2/data_set.go
+++ b/v2/data_set.go
@@ -363,7 +363,7 @@ func (dataSet *DataSet) Next(dest []driver.Value) error {
 // 	for index, arg := range args {
 // 		*arg = values[index]
 // 		// if val, ok := values[index].(t); !ok {
-// 		// 
+// 		//
 // 		// }
 // 	}
 // 	return nil

--- a/v2/driver.go
+++ b/v2/driver.go
@@ -122,7 +122,7 @@ func AddSessionParam(db *sql.DB, key, value string) error {
 // 	if err != nil {
 // 		return err
 // 	}
-// 
+//
 // 	if drv, ok := conn.Driver().(*OracleDriver); ok {
 // 		return RegisterRegularTypeArrayWithOwner(conn, drv.UserId, regularTypeName, arrayTypeName, itemMaxSize)
 // 	}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -8,6 +8,8 @@ require (
 	xorm.io/xorm v1.3.9
 )
 
+require github.com/google/go-cmp v0.5.9 // indirect
+
 require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/goccy/go-json v0.8.1 // indirect
@@ -19,5 +21,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1
+	gotest.tools/v3 v3.5.1
 	xorm.io/builder v0.3.11-0.20220531020008-1bd24a7dc978 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -16,6 +16,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -64,8 +66,11 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/gorm v1.25.11 h1:/Wfyg1B/je1hnDx3sMkX+gAlxrlZpn6X0BXRlwXlvHg=
 gorm.io/gorm v1.25.11/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
 modernc.org/cc/v3 v3.40.0 h1:P3g79IUS/93SYhtoeaHW+kRCIrYaxJ27MFPv+7kaTOw=
 modernc.org/ccgo/v3 v3.16.13 h1:Mkgdzl46i5F/CNR/Kj80Ri59hC8TKAhZrYSaqvkwzUw=

--- a/v2/tns/file.go
+++ b/v2/tns/file.go
@@ -1,0 +1,57 @@
+package tns
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ResolveFilepath resolves a path to a TNS names file.
+//
+// Returns a non-empty string if a TNS names file has been found at the path specified or
+// such a file has been found in "${TNS_ADMIN}/" folder.
+func ResolveFilepath(explicitPath string) (path string, err error) {
+	if explicitPath != "" {
+		// We've specified TNS names filepath explicitly => it must be present
+		exists, err := isExistingFile(explicitPath)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return explicitPath, nil
+		}
+		return "", fmt.Errorf("TNS Names file '%s' doesn't exist", explicitPath)
+	}
+
+	// We haven't specified TNS names filepath explicitly => try to locate the file in "${TNS_ADMIN}/",
+	// like Oracle Instant Client. In this case existence of TNS names file is not required.
+	tnsAdminDir := os.Getenv("TNS_ADMIN")
+	if tnsAdminDir == "" {
+		return "", nil
+	}
+	path = filepath.Join(tnsAdminDir, "tnsnames.ora")
+	exists, err := isExistingFile(path)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		// Found a TNS names file in "${TNS_ADMIN}/".
+		return path, nil
+	}
+	// "tnsnames.ora" file hasn't been found in "${TNS_ADMIN}/". That's fine, just return an empty string
+	return "", nil
+}
+
+// isExistingFile returns true if a file at specified path exists and is an actual file, false otherwise.
+func isExistingFile(path string) (ok bool, err error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot stat file '%s': %w", path, err)
+	}
+	return !stat.IsDir(), nil
+}

--- a/v2/tns/model.go
+++ b/v2/tns/model.go
@@ -1,0 +1,286 @@
+package tns
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TNS represents the top-level structure of a TNS (Transparent Network Substrate) configuration file.
+//
+// Docs: https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html
+type TNS struct {
+	Entries []TNSMappingEntry `yaml:"entries"`
+}
+
+// TNSMappingEntry is a mapping of network service names to connect descriptor.
+type TNSMappingEntry struct {
+	// NetServiceName is an alias mapped to network database address stored inside ConnectDescriptor.
+	NetServiceName string `yaml:"net_service_name"`
+	// ConnectDescriptor
+	ConnectDescriptor ConnectDescriptor `yaml:"connect_descriptor"`
+}
+
+// ConnectDescriptor represents a network connectivity information piece.
+//
+// In Oracle TNS configuration, you use `DESCRIPTION` and `DESCRIPTION_LIST` to define
+// network connectivity information for Oracle databases. The decision to use either depends
+// on the complexity and requirements of the network configuration.
+//
+//   - A single `DESCRIPTION` is used when you have a straightforward network configuration,
+//     where you need to define a single connection endpoint for the Oracle database. It includes
+//     details such as the protocol, host, and port.
+//
+//     Example of a single `DESCRIPTION`:
+//
+//     ORCLDB =
+//     (DESCRIPTION =
+//     (ADDRESS = (PROTOCOL = TCP)(HOST = myhost)(PORT = 1521))
+//     (CONNECT_DATA =
+//     (SERVER = DEDICATED)
+//     (SERVICE_NAME = orcl)
+//     )
+//     )
+//
+//   - `DESCRIPTION_LIST` is used for more complex network configurations, such as load balancing,
+//     failover, or when you need to define multiple connection endpoints for redundancy or distribution.
+//     Each `DESCRIPTION` in the `DESCRIPTION_LIST` can specify separate connection details.
+//
+//     Example of `DESCRIPTION_LIST`:
+//
+//     ORCLDB =
+//     (DESCRIPTION_LIST =
+//     (LOAD_BALANCE = ON)
+//     (FAILOVER = ON)
+//     (DESCRIPTION =
+//     (ADDRESS = (PROTOCOL = TCP)(HOST = myhost1)(PORT = 1521))
+//     (CONNECT_DATA =
+//     (SERVER = DEDICATED)
+//     (SERVICE_NAME = orcl1)
+//     )
+//     )
+//     (DESCRIPTION =
+//     (ADDRESS = (PROTOCOL = TCP)(HOST = myhost2)(PORT = 1522))
+//     (CONNECT_DATA =
+//     (SERVER = DEDICATED)
+//     (SERVICE_NAME = orcl2)
+//     )
+//     )
+//     )
+//
+//     Note: `LOAD_BALANCE` and `FAILOVER` options can be used to distribute connections and provide redundancy.
+//
+//   - Multiple `ADDRESS` entries within a single `DESCRIPTION` are used to define multiple potential endpoints
+//     for a single logical connection configuration. This supports connection failover within the same configuration context.
+//
+//     Example of multiple `ADDRESS` entries:
+//
+//     ORCLDB =
+//     (DESCRIPTION =
+//     (ADDRESS_LIST =
+//     (LOAD_BALANCE = OFF)
+//     (FAILOVER = ON)
+//     (ADDRESS = (PROTOCOL = TCP)(HOST = myhost1)(PORT = 1521))
+//     (ADDRESS = (PROTOCOL = TCP)(HOST = myhost2)(PORT = 1521))
+//     )
+//     (CONNECT_DATA =
+//     (SERVER = DEDICATED)
+//     (SERVICE_NAME = orcl)
+//     )
+//     )
+//
+//   - This configuration primarily supports failover, though it can also be used for manual load balancing.
+//
+//   - Both addresses point to the same logical SERVICE_NAME, indicating they service the same database.
+//
+// Differences:
+//
+// - **Multiple `DESCRIPTION` Entries (in `DESCRIPTION_LIST`)**
+//   - Support both load balancing (`LOAD_BALANCE = ON`) and failover (`FAILOVER = ON`).
+//   - Each `DESCRIPTION` can be a completely different configuration, potentially pointing to different database instances.
+//   - Ideal for complex configurations requiring high availability and distribution among different services.
+//
+// - **Multiple `ADDRESS` Entries (in One `DESCRIPTION`)**
+//   - Primarily support failover, though load balancing can be manually configured.
+//   - All addresses share the same logical `CONNECT_DATA`, meaning they refer to the same database instance/service.
+//   - Ideal for redundancy and high availability connecting to the same database service through multiple network paths.
+//
+// TNS provides a way to represent both configurations within a Go struct:
+// - `Description` is used for the single `DESCRIPTION` configuration.
+// - `DescriptionList` is used for the `DESCRIPTION_LIST` configuration to handle multiple `DESCRIPTION` entries.
+type ConnectDescriptor struct {
+	// The DESCRIPTION_LIST parameter of the tnsnames.ora file defines a list of connect descriptors for a particular net service name.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-C5C15BAA-A493-49DB-8D62-ECE520EADD8F
+	DescriptionList DescriptionList `yaml:"description_list"`
+
+	// The DESCRIPTION parameter of the tnsnames.ora file defines a connect descriptor for a particular net service name.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-6540A1EC-93B2-43BD-B462-1277B82EAE25
+	Description Description `yaml:"description"` // Represents a single DESCRIPTION configuration.
+}
+
+type DescriptionList struct {
+	Descriptions []Description `yaml:"description"`
+}
+
+type Description struct {
+	// It's really messy how Oracle handle addresses in TNS files.
+	//
+	// According to the docs, ADDRESS_LIST is not required, and was introduced in Oracle 8.0. Before that, ADDRESS was used
+	// directly under DESCRIPTION.
+	//
+	// It looks like, that should be merged... But the tricky detail is that AddressList has additional properties,
+	// that should be applied to that addresses, but not to the addresses under DESCRIPTION.
+	AddressList  `yaml:",inline"` // FIXME: An embedded AddressList structure, without ADDRESS_LIST prefix
+	AddressLists []AddressList    `yaml:"address_list"` // A list of lists of addresses
+
+	RetryCount              int         `yaml:"retry_count,omitempty"`               // The number of times to retry a connection, e.g., 3
+	TransportConnectTimeout int         `yaml:"transport_connect_timeout,omitempty"` // The number of seconds to wait for a transport connection to be established, e.g., 30
+	ConnectTimeout          int         `yaml:"connect_timeout,omitempty"`           // The number of seconds to wait for a connection to be established, e.g., 30
+	ConnectData             ConnectData `yaml:"connect_data,omitempty"`              // A ConnectData structure containing the service name, e.g., {"service_name": "sales.us.example.com"}
+	Security                Security    `yaml:"security,omitempty"`                  // A Security structure containing the SSL server certificate DN, e.g., {"ssl_server_cert_dn": "CN=server.example.com,OU=Example,O=Example,L=Example,ST=Example,C=US"}
+	EncryptionClient        string      `yaml:"encryption_client,omitempty"`         // Added encryption client
+	AuthenticationServices  string      `yaml:"authentication_services,omitempty"`   // Added authentication services
+	Compression             string      `yaml:"compression,omitempty"`               // Enable or disable data compression, e.g., "on"
+	CompressionLevels       []string    `yaml:"compression_levels,omitempty"`        // Specify the compression levels, e.g., ["low", "high"]
+}
+
+// AddressList represents a list of addresses and source routing information.
+type AddressList struct {
+	Address       []Address `yaml:"address"`         // A list of Address structures, e.g., [{"host": "host1.example.com", "port": 1521, "protocol": "tcp"}]
+	Enable        string    `yaml:"enable"`          // The keepalive feature, e.g., "broken"
+	Failover      string    `yaml:"failover"`        // Indicates if failover is enabled (reoriented relevant property)
+	LoadBalance   string    `yaml:"load_balance"`    // Indicates if load balancing is enabled (reoriented relevant property)
+	RecvBufSize   int       `yaml:"recv_buf_size"`   // The buffer space for receive operations, e.g., 11784
+	Sdu           int       `yaml:"sdu"`             // The session data unit size, e.g., 8192
+	SendBufSize   int       `yaml:"send_buf_size"`   // The buffer space for send operations, e.g., 11784
+	SourceRoute   string    `yaml:"source_route"`    // Indicates whether source routing is enabled (yes or no), e.g., "yes"
+	TypeOfService string    `yaml:"type_of_service"` // The type of service for an Oracle Rdb database, e.g., "rdb_database"
+}
+
+type Address struct {
+	Host     string `yaml:"host"`     // The hostname or IP address of the server, e.g., "host1.example.com"
+	Port     int    `yaml:"port"`     // The port number on which the server is listening, e.g., 1521
+	Protocol string `yaml:"protocol"` // The protocol used for communication, e.g., "tcp"
+
+	//  The HTTPS proxy server, e.g., "proxy.example.com:80"
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-C672E92D-CE32-4759-9931-92D7960850F7
+	HttpsProxyHost string `yaml:"https_proxy"`
+
+	// The HTTPS proxy port, e.g., 80
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-C672E92D-CE32-4759-9931-92D7960850F7
+	HttpsProxyPort int `yaml:"https_proxy_port"`
+
+	SendBufSize int `yaml:"send_buf_size"` // The buffer space for send operations of sessions, e.g., 11784
+	RecvBufSize int `yaml:"recv_buf_size"` // The buffer space for receive operations of sessions, e.g., 11784
+}
+
+type ConnectData struct {
+	// ColocationTag is used to specify a colocation tag for the connection.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-9D06528E-BBC4-4629-A119-C216EBF70201
+	ColocationTag string `yaml:"colocation_tag"`
+
+	// ConnectionIdPrefix is used to specify a prefix for the connection ID.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-9C46B9AF-4582-46DC-8D21-5F5F686983BA
+	ConnectionIdPrefix string `yaml:"connection_id_prefix"`
+
+	// PoolConnectionClass is used to specify the connection class for the connection pool.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-FC3A42EA-2809-4B7E-A969-E962B8C25906
+	PoolConnectionClass string `yaml:"pool_connection_class"`
+
+	// PoolPurity is used to specify the purity of the connection pool.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-640A7C66-CF4C-47C4-A725-F6E1097C460D
+	PoolPurity string `yaml:"pool_purity"`
+
+	// ShardingKey is used to specify the sharding key for the connection.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-9254F571-77DA-4345-9B20-9460DBF43B3D
+	ShardingKey string `yaml:"sharding_key"`
+
+	// SuperShardingKey is used to specify the super sharding key for the connection.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-8AA96248-466D-423D-A516-235B41A3C24A
+	SuperShardingKey string `yaml:"super_sharding_key"`
+
+	// TunnelServiceName is used to specify the tunnel service name for the connection.
+	//
+	// https://docs.oracle.com/en/database/oracle/oracle-database/21/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-7DF419C2-3237-4B79-9AA3-EA1C2D786712
+	TunnelServiceName string `yaml:"tunnel_service_name"`
+
+	FailoverMode string     `yaml:"failover_mode"` // The failover mode, e.g., "BASIC"
+	GlobalName   string     `yaml:"global_name"`   // The global name of the Oracle Rdb database, e.g., "alpha5"
+	Hs           string     `yaml:"hs"`            // Indicates connection to a non-Oracle system through Heterogeneous Services, e.g., "ok"
+	InstanceName string     `yaml:"instance_name"` // The database instance to access, e.g., "sales1"
+	RdbDatabase  string     `yaml:"rdb_database"`  // The file name of an Oracle Rdb database, e.g., "[.mf]mf_personal.rdb"
+	Server       ServerType `yaml:"server"`        // The type of server connection, e.g., "dedicated", "shared", or "pooled"
+	ServiceName  string     `yaml:"service_name"`  // The name of the service to connect to, e.g., "sales.us.example.com"
+	Sid          string     `yaml:"sid"`           // The Oracle System Identifier (SID), e.g., "sales6"
+}
+
+type Security struct {
+	SslServerCertDN       string `yaml:"ssl_server_cert_dn"`     // The distinguished name of the server's SSL certificate, e.g., "CN=server.example.com,OU=Example,O=Example,L=Example,ST=Example,C=US"
+	AuthenticationService string `yaml:"authentication_service"` // The authentication service to use, e.g., "KERBEROS5"
+	IgnoreAnoEncryption   bool   `yaml:"ignore_ano_encryption"`  // Whether to ignore ANO encryption for TCPS, e.g., true
+	Kerberos5CCName       string `yaml:"kerberos5_cc_name"`      // The complete path name to the Kerberos credentials cache (CC) file, e.g., "/tmp/kcache"
+	SslServerDNMatch      bool   `yaml:"ssl_server_dn_match"`    // Whether to enforce server-side certificate validation through DN matching, e.g., true
+	SslVersion            string `yaml:"ssl_version"`            // The version of TLS to use, e.g., "1.2"
+	WalletLocation        string `yaml:"wallet_location"`        // The location where Oracle wallets are stored, e.g., "/home/oracle/wallets/databases"
+}
+
+// ServerType represents the type of server connection.
+type ServerType string
+
+const (
+	// Dedicated server type.
+	Dedicated ServerType = "dedicated"
+	// Shared server type.
+	Shared ServerType = "shared"
+	// Pooled server type.
+	Pooled ServerType = "pooled"
+)
+
+var (
+	_ yaml.Marshaler   = (*ServerType)(nil)
+	_ yaml.Unmarshaler = (*ServerType)(nil)
+)
+
+func (j *ServerType) MarshalYAML() (interface{}, error) {
+	return yaml.Marshal(string(*j))
+}
+
+func (j *ServerType) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+
+	t := ServerType(strings.ToLower(s))
+	switch t {
+	case Dedicated, Shared, Pooled:
+		*j = t
+		return nil
+	default:
+		return fmt.Errorf("invalid server type: %s", t)
+	}
+}
+
+// GetDescriptorForService returns a connect descriptor for the specified service.
+//
+// Returns nil if there's no connect descriptor for the specified service.
+func (t *TNS) GetDescriptorForService(name string) *ConnectDescriptor {
+	for _, cd := range t.Entries {
+		if cd.NetServiceName == name {
+			desc := cd.ConnectDescriptor
+			return &desc
+		}
+	}
+	return nil
+}

--- a/v2/tns/parser.go
+++ b/v2/tns/parser.go
@@ -1,0 +1,197 @@
+package tns
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type parser struct {
+	tns           []rune
+	pos           int // next position to read
+	lowerCaseKeys bool
+}
+
+// consume consumes TNS names
+func (p *parser) consume() (any, error) {
+	// Iterate over runes in TNS string
+	var entries []any
+	for {
+		if p.isEndReached() {
+			break
+		}
+		// Consume a TNS mapping entry
+		entry, err := p.consumeMappingEntry()
+		if err != nil {
+			return nil, fmt.Errorf("failed to consume a mapping entry: %w", err)
+		}
+		entries = append(entries, entry)
+	}
+	// Return a TNS-like object with TNS mapping entries
+	return map[string]any{"entries": entries}, nil
+}
+
+// consumeMappingEntry consumes a "net service name" -> "connect descriptor" entry
+func (p *parser) consumeMappingEntry() (any, error) {
+	// Consume whitespace
+	_ = p.consumeWhitespace()
+	// Consume a net service name
+	netServiceName, err := p.consumeStringValue('=')
+	if err != nil {
+		return nil, fmt.Errorf("failed to consume a net service name: %w", err)
+	}
+	// Consume '='
+	if r := p.consumeRune(); r != '=' {
+		return nil, fmt.Errorf("expected '=', got '%s'", string(r))
+	}
+	// Consume a connect descriptor
+	connDesc, err := p.consumeValue()
+	if err != nil {
+		return nil, fmt.Errorf("failed to consume a connect descriptor: %w", err)
+	}
+	// Return a TNS mapping entry
+	return map[string]any{
+		"net_service_name":   netServiceName,
+		"connect_descriptor": connDesc,
+	}, nil
+}
+
+// consumeValue consumes a TNS value in brackets '()'.
+//
+// Such value can be a whole connect descriptor or a parameter entry.
+func (p *parser) consumeValue() (any, error) {
+	_ = p.consumeWhitespace()
+	switch p.lookAhead() {
+	case '(':
+		return p.consumeObjectLiteral()
+	default:
+		return p.consumeScalarValue(')')
+	}
+}
+
+// consumeStringValue consumes string literal until terminator rune, not consuming the terminator rune itself.
+//
+// Initial and trailing whitespace is ignored.
+//
+// It returns the string and an error if the string is not terminated.
+func (p *parser) consumeStringValue(terminator rune) (string, error) {
+	var str strings.Builder
+	for {
+		r := p.lookAhead()
+		if r == terminator {
+			break
+		}
+		if r == stopRune {
+			return "", fmt.Errorf("unexpected end of string")
+		}
+		_ = p.consumeRune()
+		str.WriteRune(r)
+	}
+	// ignore whitespace
+	return strings.TrimSpace(str.String()), nil
+}
+
+// consumeScalarValue consumes string literal until terminator rune, not consuming the terminator rune itself
+//
+// Initial and trailing whitespace is ignored.
+//
+// The type is automatically inferred:
+// - abc -> string("abc")
+// - 123 -> int(123)
+// - 123.45 -> float64(123.45)
+func (p *parser) consumeScalarValue(terminator rune) (any, error) {
+	data, err := p.consumeStringValue(terminator)
+	if err != nil {
+		return nil, err
+	}
+	// try to parse as int
+	if i, err := strconv.Atoi(data); err == nil {
+		return i, nil
+	}
+	// try to parse as float
+	if f, err := strconv.ParseFloat(data, 64); err == nil {
+		return f, nil
+	}
+	// not a number —> it's a string
+	return data, nil
+}
+
+// consumeObjectLiteral consumes object and returns it as a map
+//
+// Here are the rules:
+// - Single key: (key=value) -> map[key] = value
+// - Different keys make a map: (key1=value1)(key2=value2) -> map[key1] = value1, map[key2] = value2
+// - Repetition of the same key makes array of values: (key1=value1)(key1=value2) -> map[key1] = [value1, value2]
+//
+// Whitespace is ignored.
+//
+// Value can be either string or another object. Thus it can be recursive.
+func (p *parser) consumeObjectLiteral() (map[string]any, error) {
+	obj := make(map[string][]any)
+
+	for {
+		_ = p.consumeWhitespace()
+
+		// initial rune of the object
+		r := p.lookAhead()
+		if r != '(' {
+			return p.compressObject(obj), nil
+		}
+
+		// ok, we have a key-value pair
+		_ = p.consumeRune()
+
+		// skip leading whitespace
+		_ = p.consumeWhitespace()
+
+		key, err := p.consumeStringValue('=')
+		if err != nil {
+			return nil, err
+		}
+
+		if key == "" {
+			return nil, fmt.Errorf("empty key")
+		}
+
+		if p.lowerCaseKeys {
+			key = strings.ToLower(key)
+		}
+
+		if p.consumeRune() != '=' {
+			return nil, fmt.Errorf("expected '='")
+		}
+
+		value, err := p.consumeValue()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.consumeRune() != ')' {
+			return nil, fmt.Errorf("expected ')'")
+		}
+
+		obj[key] = append(obj[key], value)
+	}
+}
+
+// FIXME: this is a temporary solution, does not take into account hierarchy
+var alwaysArray = map[string]struct{}{
+	"address":      {},
+	"address_list": {},
+}
+
+func (p *parser) compressObject(in map[string][]any) map[string]any {
+	out := make(map[string]any)
+	for k, v := range in {
+		if _, ok := alwaysArray[strings.ToLower(k)]; ok {
+			out[k] = v
+			continue
+		}
+		if len(v) == 1 {
+			out[k] = v[0]
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/v2/tns/parser_funcs.go
+++ b/v2/tns/parser_funcs.go
@@ -1,0 +1,47 @@
+package tns
+
+import "unicode"
+
+const stopRune rune = 0
+
+// lookAhead returns next rune, without consuming it
+func (p *parser) lookAhead() rune {
+	if p.isEndReached() {
+		return stopRune
+	}
+	return p.tns[p.pos]
+}
+
+// isEndReached returns true if current parser position is out of bounds of the provided TNS slice.
+func (p *parser) isEndReached() bool {
+	return p.pos >= len(p.tns)
+}
+
+// consumeRune consumes one rune
+func (p *parser) consumeRune() rune {
+	if p.isEndReached() {
+		return stopRune
+	}
+	r := p.tns[p.pos]
+	p.pos += 1
+	return r
+}
+
+// consumeWhitespace consumes all whitespace (if any) and stops before the next non-space rune
+//
+// reports number of runes consumed
+func (p *parser) consumeWhitespace() int {
+	var cnt int
+	for {
+		r := p.lookAhead()
+		if r == stopRune {
+			break
+		}
+		if !unicode.IsSpace(r) {
+			break
+		}
+		_ = p.consumeRune()
+		cnt++
+	}
+	return cnt
+}

--- a/v2/tns/parser_test.go
+++ b/v2/tns/parser_test.go
@@ -1,0 +1,168 @@
+package tns
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConsumeScalarValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		terminator rune
+		expected   any
+		expectErr  bool
+	}{
+		{
+			name:       "simple string",
+			input:      "abc)",
+			terminator: ')',
+			expected:   "abc",
+			expectErr:  false,
+		},
+		{
+			name:       "integer",
+			input:      "123)",
+			terminator: ')',
+			expected:   123,
+			expectErr:  false,
+		},
+		{
+			name:       "float",
+			input:      "123.45)",
+			terminator: ')',
+			expected:   123.45,
+			expectErr:  false,
+		},
+		{
+			name:       "unexpected end of string",
+			input:      "abc",
+			terminator: ')',
+			expected:   "",
+			expectErr:  true,
+		},
+		{
+			name:       "whitespace around string",
+			input:      "  abc  )",
+			terminator: ')',
+			expected:   "abc",
+			expectErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := parser{
+				tns: []rune(tt.input),
+				pos: 0,
+			}
+			result, err := p.consumeScalarValue(tt.terminator)
+			if tt.expectErr {
+				assert.Equal(t, err != nil, true)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConsumeObjectLiteral(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  map[string]any
+		expectErr bool
+	}{
+		{
+			name:  "simple object",
+			input: "(key=value)",
+			expected: map[string]any{
+				"key": "value",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "multiple keys",
+			input: "(key1=value1)(key2=value2)",
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "repeated keys",
+			input: "(key=value1)(key=value2)",
+			expected: map[string]any{
+				"key": []any{"value1", "value2"},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "nested objects",
+			input: "(key=(nestedKey=nestedValue))",
+			expected: map[string]any{
+				"key": map[string]any{
+					"nestedKey": "nestedValue",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "spaces between key and value",
+			input: "(key = value)",
+			expected: map[string]any{
+				"key": "value",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "spaces between key-value pairs",
+			input: "(key1=value1) (key2=value2)",
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "spaces around key-value pairs",
+			input: " ( key1 = value1 ) ( key2 = value2 ) ",
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectErr: false,
+		},
+		{
+			name:      "unexpected end of string",
+			input:     "(key=value",
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "empty key",
+			input:     "(=value)",
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := parser{
+				tns: []rune(tt.input),
+				pos: 0,
+			}
+			result, err := p.consumeObjectLiteral()
+			if tt.expectErr {
+				assert.Equal(t, err != nil, true)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, result, tt.expected)
+			}
+		})
+	}
+}

--- a/v2/tns/tns.go
+++ b/v2/tns/tns.go
@@ -1,0 +1,37 @@
+package tns
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Parse parses a TNS string and returns a TNS struct.
+func Parse(tnsStr string) (*TNS, error) {
+	yamlData, err := toYaml(tnsStr)
+	if err != nil {
+		return nil, err
+	}
+	var tns TNS
+	err = yaml.Unmarshal(yamlData, &tns)
+	if err != nil {
+		return nil, err
+	}
+	return &tns, nil
+}
+
+func toYaml(tns string) ([]byte, error) {
+	p := parser{
+		tns:           []rune(tns),
+		lowerCaseKeys: true,
+	}
+	parsedTns, err := p.consume()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TNS: %w", err)
+	}
+	tnsYaml, err := yaml.Marshal(parsedTns)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+	return tnsYaml, nil
+}

--- a/v2/tns/tns_test.go
+++ b/v2/tns/tns_test.go
@@ -1,0 +1,277 @@
+package tns
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		tnsStr   string
+		expected *TNS
+		wantErr  bool
+	}{
+		{
+			name: "Single Description",
+			tnsStr: `mysuperhost = (DESCRIPTION=
+				(ADDRESS=(PROTOCOL=tcp)(HOST=myhost)(PORT=1521))
+				(CONNECT_DATA=
+					(SERVER=DEDICATED)
+					(SERVICE_NAME=orcl)
+				)
+			)`,
+			expected: &TNS{
+				Entries: []TNSMappingEntry{
+					{
+						NetServiceName: "mysuperhost",
+						ConnectDescriptor: ConnectDescriptor{
+							Description: Description{
+								AddressList: AddressList{
+									Address: []Address{
+										{Host: "myhost", Port: 1521, Protocol: "tcp"},
+									},
+								},
+								ConnectData: ConnectData{
+									Server:      Dedicated,
+									ServiceName: "orcl",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Single Description, Multiple mappings",
+			tnsStr: `mysuperhost = (DESCRIPTION=
+				(ADDRESS=(PROTOCOL=tcp)(HOST=myhost)(PORT=1521))
+				(CONNECT_DATA=
+					(SERVER=DEDICATED)
+					(SERVICE_NAME=orcl)
+				)
+			)
+				
+			mysuperhost2 = (DESCRIPTION=
+				(ADDRESS=(PROTOCOL=tcp)(HOST=myhost2)(PORT=1522))
+				(CONNECT_DATA=
+					(SERVER=DEDICATED)
+					(SERVICE_NAME=orcl2)
+				)
+			)`,
+			expected: &TNS{
+				Entries: []TNSMappingEntry{
+					{
+						NetServiceName: "mysuperhost",
+						ConnectDescriptor: ConnectDescriptor{
+							Description: Description{
+								AddressList: AddressList{
+									Address: []Address{
+										{Host: "myhost", Port: 1521, Protocol: "tcp"},
+									},
+								},
+								ConnectData: ConnectData{
+									Server:      Dedicated,
+									ServiceName: "orcl",
+								},
+							},
+						},
+					},
+					{
+						NetServiceName: "mysuperhost2",
+						ConnectDescriptor: ConnectDescriptor{
+							Description: Description{
+								AddressList: AddressList{
+									Address: []Address{
+										{Host: "myhost2", Port: 1522, Protocol: "tcp"},
+									},
+								},
+								ConnectData: ConnectData{
+									Server:      Dedicated,
+									ServiceName: "orcl2",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple Descriptions",
+			tnsStr: `mysuperhost2 = (DESCRIPTION_LIST=
+				(DESCRIPTION=
+					(ADDRESS=(PROTOCOL=tcp)(HOST=myhost1)(PORT=1521))
+					(CONNECT_DATA=
+						(SERVER=DEDICATED)
+						(SERVICE_NAME=orcl1)
+					)
+				)
+				(DESCRIPTION=
+					(ADDRESS=(PROTOCOL=tcp)(HOST=myhost2)(PORT=1522))
+					(CONNECT_DATA=
+						(SERVER=DEDIcATED)
+						(SERVICE_NAME=orcl2)
+					)
+				)
+			)`,
+			expected: &TNS{
+				Entries: []TNSMappingEntry{
+					{
+						NetServiceName: "mysuperhost2",
+						ConnectDescriptor: ConnectDescriptor{
+							DescriptionList: DescriptionList{
+								Descriptions: []Description{
+									{
+										AddressList: AddressList{
+											Address: []Address{
+												{Host: "myhost1", Port: 1521, Protocol: "tcp"},
+											},
+										},
+										ConnectData: ConnectData{
+											Server:      Dedicated,
+											ServiceName: "orcl1",
+										},
+									},
+									{
+										AddressList: AddressList{
+											Address: []Address{
+												{Host: "myhost2", Port: 1522, Protocol: "tcp"},
+											},
+										},
+										ConnectData: ConnectData{
+											Server:      Dedicated,
+											ServiceName: "orcl2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple Descriptions, Multiple entries",
+			tnsStr: `mysuperhost2 = (DESCRIPTION_LIST=
+				(DESCRIPTION=
+					(ADDRESS=(PROTOCOL=tcp)(HOST=myhost1)(PORT=1521))
+					(CONNECT_DATA=
+						(SERVER=DEDICATED)
+						(SERVICE_NAME=orcl1)
+					)
+				)
+				(DESCRIPTION=
+					(ADDRESS=(PROTOCOL=tcp)(HOST=myhost2)(PORT=1522))
+					(CONNECT_DATA=
+						(SERVER=DEDIcATED)
+						(SERVICE_NAME=orcl2)
+					)
+				)
+			)
+				
+			mysuperhost3 = (DESCRIPTION=
+				(ADDRESS=(PROTOCOL=tcp)(HOST=myhost3)(PORT=1523))
+				(CONNECT_DATA=
+					(SERVER=DEDICATED)
+					(SERVICE_NAME=orcl3)
+				)
+			)`,
+			expected: &TNS{
+				Entries: []TNSMappingEntry{
+					{
+						NetServiceName: "mysuperhost2",
+						ConnectDescriptor: ConnectDescriptor{
+							DescriptionList: DescriptionList{
+								Descriptions: []Description{
+									{
+										AddressList: AddressList{
+											Address: []Address{
+												{Host: "myhost1", Port: 1521, Protocol: "tcp"},
+											},
+										},
+										ConnectData: ConnectData{
+											Server:      Dedicated,
+											ServiceName: "orcl1",
+										},
+									},
+									{
+										AddressList: AddressList{
+											Address: []Address{
+												{Host: "myhost2", Port: 1522, Protocol: "tcp"},
+											},
+										},
+										ConnectData: ConnectData{
+											Server:      Dedicated,
+											ServiceName: "orcl2",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						NetServiceName: "mysuperhost3",
+						ConnectDescriptor: ConnectDescriptor{
+							Description: Description{
+								AddressList: AddressList{
+									Address: []Address{
+										{Host: "myhost3", Port: 1523, Protocol: "tcp"},
+									},
+								},
+								ConnectData: ConnectData{
+									Server:      Dedicated,
+									ServiceName: "orcl3",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Net Service Name as <host>:<port>/<service>",
+			tnsStr: `myhost:1523/db=(
+				DESCRIPTION=
+					(ADDRESS=(PROTOCOL=TCP)(HOST=1.2.3.4)(PORT=1523))
+					(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=db))
+			)`,
+			expected: &TNS{
+				Entries: []TNSMappingEntry{
+					{
+						NetServiceName: "myhost:1523/db",
+						ConnectDescriptor: ConnectDescriptor{
+							Description: Description{
+								AddressList: AddressList{
+									Address: []Address{
+										{Host: "1.2.3.4", Port: 1523, Protocol: "TCP"},
+									},
+								},
+								ConnectData: ConnectData{
+									Server:      Dedicated,
+									ServiceName: "db",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.tnsStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.DeepEqual(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Hi.

This PR adds basic support of TNS Names files to `go-ora`.

Support includes:
1. reading and parsing TNS Names files either specified explicitly via connection URL options (`TNS NAMES` property) or found at `${TNS_ADMIN}/tnsnames.ora`. Existing ANTLR grammars for such files are not full, therefore an own implementation of the parser was written.
2. using data from TNS Names to resolve net service names from connection URL-s to actual database server addresses.

Support is pretty basic at the moment - various features like fail-over, load balancing and others, which can be specified in TNS Names files via corresponding properties, are not supported at the moment. Implementation is trying to be as fail-fast as possible - if an unsupported property is present in the resolved TNS Names file, `go-ora` will fail.

`README.md` has also been modified accordingly.

Thanks.