### PR TITLE
Add ErrPos() interface to OracleError

### DIFF
--- a/network/oracle_error.go
+++ b/network/oracle_error.go
@@ -10,6 +10,7 @@ func (err *OracleError) Error() string {
 	return err.ErrMsg
 }
 
+// ErrPos return sql error position。
 func (err *OracleError) ErrPos() int {
 	return err.errPos
 }

--- a/network/oracle_error.go
+++ b/network/oracle_error.go
@@ -3,10 +3,15 @@ package network
 type OracleError struct {
 	ErrCode int
 	ErrMsg  string
+	errPos  int
 }
 
 func (err *OracleError) Error() string {
 	return err.ErrMsg
+}
+
+func (err *OracleError) ErrPos() int {
+	return err.errPos
 }
 
 func (err *OracleError) translate() {

--- a/network/session.go
+++ b/network/session.go
@@ -506,6 +506,7 @@ func (session *Session) GetError() *OracleError {
 		} else {
 			err.ErrMsg = string(session.Summary.ErrorMessage)
 		}
+		err.errPos = session.Summary.errorPos
 	}
 	return err
 }

--- a/v2/network/oracle_error.go
+++ b/v2/network/oracle_error.go
@@ -8,6 +8,7 @@ import (
 type OracleError struct {
 	ErrCode int
 	ErrMsg  string
+	errPos  int
 }
 
 func (err *OracleError) Error() string {
@@ -15,6 +16,11 @@ func (err *OracleError) Error() string {
 		err.translate()
 	}
 	return err.ErrMsg
+}
+
+// ErrPos return sql error position。
+func (err *OracleError) ErrPos() int {
+	return err.errPos
 }
 
 func (err *OracleError) translate() {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -483,7 +483,7 @@ func (session *Session) BreakConnection() error {
 	// 		return nil, err
 	// 	}
 	// } else {
-	// 
+	//
 	// }
 	// ret := make([]PacketInterface, 0, 2)
 	// var pck PacketInterface
@@ -723,7 +723,7 @@ func (session *Session) processMarker() error {
 	// receive all packet until you get marker
 	// var pck PacketInterface = nil
 	// for pck == nil || pck.getPacketType() != MARKER {
-	// 
+	//
 	// 	if session.isFinalPacketRead {
 	// 		break
 	// 	}
@@ -942,6 +942,7 @@ func (session *Session) GetError() *OracleError {
 		} else {
 			err.ErrMsg = string(session.Summary.ErrorMessage)
 		}
+		err.errPos = session.Summary.errorPos
 	}
 	return err
 }
@@ -1345,7 +1346,7 @@ func (session *Session) readPacket() (PacketInterface, error) {
 		// 	default:
 		// 		return nil, errors.New(fmt.Sprintf("TTC error: received code %d during stmt reading", msg))
 		// 	}
-		// 
+		//
 		// }
 		// fallthrough
 	default:
@@ -1706,7 +1707,7 @@ func (session *Session) GetClr() (output []byte, err error) {
 	// 	output, err = session.read(int(size))
 	// 	return
 	// }
-	// 
+	//
 	// for {
 	// 	var size1 int
 	// 	if session.UseBigClrChunks {
@@ -1995,18 +1996,18 @@ func (session *Session) WriteKeyVal(buffer *bytes.Buffer, key []byte, val []byte
 // 	}
 // 	return ret, nil
 // }
-// 
+//
 // func (session *Session) ReadInt(buffer *bytes.Buffer, size int, compress, bigEndian bool) (int, error) {
 // 	temp, err := session.ReadInt64(buffer, size, compress, bigEndian)
 // 	return int(temp), err
 // }
-// 
+//
 // func (session *Session) ReadBytes(buffer *bytes.Buffer, size int) ([]byte, error) {
 // 	temp := make([]byte, size)
 // 	_, err := buffer.Read(temp)
 // 	return temp, err
 // }
-// 
+//
 // func (session *Session)ReadClr(buffer *bytes.Buffer) (output []byte, err error){
 // 	var size uint8
 // 	var rb []byte
@@ -2043,7 +2044,7 @@ func (session *Session) WriteKeyVal(buffer *bytes.Buffer, key []byte, val []byte
 // 	output = tempBuffer.Bytes()
 // 	return
 // }
-// 
+//
 // func (session *Session)ReadDlc(buffer *bytes.Buffer) (output []byte, err error) {
 // 	var length int
 // 	length, err = session.ReadInt(buffer, 4, true, true)


### PR DESCRIPTION
Add ErrPos() interface to OracleError, which makes it easier for users to be informed of the specific location where the error occurred.