### PR TITLE
Fix panic at number decoding

### DIFF
--- a/v2/number.go
+++ b/v2/number.go
@@ -185,6 +185,10 @@ func (num *Number) decode() (strNum string, exp int, negative bool, err error) {
 	}
 
 	buf := num.data[1:]
+	if len(buf) == 0 {
+		err = fmt.Errorf("invalid NUMBER")
+		return
+	}
 	if negative && buf[len(buf)-1] == 0x66 {
 		buf = buf[:len(buf)-1]
 	}


### PR DESCRIPTION
In the decode() function for the NUMBER data type, there is no array size check, which leads to array overruns and panic at decoding some incorrectly generated values in the database:

```
panic: runtime error: index out of range [-1]

goroutine 25 [running]:
github.com/sijms/go-ora/v2.(*Number).decode(0x0?)
    /.../github.com/sijms/go-ora/v2/number.go:188 +0x27f
```