### PR TITLE
Handle type assertion correctly

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -1135,9 +1135,12 @@ func (conn *Connection) QueryRowContext(ctx context.Context, query string, args 
 	stmt := NewStmt(query, conn)
 	stmt.autoClose = true
 	rows, err := stmt.QueryContext(ctx, args)
-	dataSet := rows.(*DataSet)
 	if err != nil {
 		return &DataSet{lasterr: err}
+	}
+	dataSet, ok := rows.(*DataSet)
+	if !ok {
+		return &DataSet{lasterr: errors.New("type object should be *DataSet")}
 	}
 	dataSet.Next_()
 	return dataSet


### PR DESCRIPTION
## Description
Currently, the code tries to do a type assertion before verifying no error was returned from `QueryContext`, additionally, it is not verifying the type assertion worked properly. 

This PR adds correct error and type assertion handling to the `QueryRowContext` function. 