### PR TITLE
fix "panic: interface conversion: driver.Rows is nil, not *go_ora.Dat…

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -1135,10 +1135,10 @@ func (conn *Connection) QueryRowContext(ctx context.Context, query string, args 
 	stmt := NewStmt(query, conn)
 	stmt.autoClose = true
 	rows, err := stmt.QueryContext(ctx, args)
-	dataSet := rows.(*DataSet)
 	if err != nil {
 		return &DataSet{lasterr: err}
 	}
+	dataSet := rows.(*DataSet)
 	dataSet.Next_()
 	return dataSet
 }


### PR DESCRIPTION
A running statement during the shutdown leads to a crash

`ORA-01089: immediate shutdown or close in progress - no operations are permitted` followed by `ORA-12518` and 

```
panic: interface conversion: driver.Rows is nil, not *go_ora.DataSet

goroutine 22 [running]:
github.com/sijms/go-ora/v2.(*Connection).QueryRowContext(0x2?, {0x25cbe80, 0x38dca00}, {0x1a25ac2?, 0x10?}, {0x0, 0x0, 0x0})
	/builds/middleware/agent/vendor/github.com/sijms/go-ora/v2/connection.go:1129 +0x105
github.com/sijms/go-ora/v2.(*Connection).getDBTimeZone(0xc000be2288)
	/builds/middleware/agent/vendor/github.com/sijms/go-ora/v2/connection.go:545 +0x6d
github.com/sijms/go-ora/v2.(*Connection).dataTypeNegotiation(0xc000be2288)
	/builds/middleware/agent/vendor/github.com/sijms/go-ora/v2/connection.go:1335 +0x1ae
github.com/sijms/go-ora/v2.(*Connection).OpenWithContext(0xc000be2288, {0x25cbf28, 0xc0002002d0})
	/builds/middleware/agent/vendor/github.com/sijms/go-ora/v2/connection.go:475 +0xaaa
github.com/sijms/go-ora/v2.(*OracleConnector).Connect(0xc001caa6c0, {0x25cbf28, 0xc0002002d0})
	/builds/middleware/agent/vendor/github.com/sijms/go-ora/v2/connection.go:152 +0x1a5
database/sql.(*DB).conn(0xc001869c70, {0x25cbf28, 0xc0002002d0}, 0x1)
	/usr/local/go/src/database/sql/sql.go:1415 +0x71e
database/sql.(*DB).Conn.func1(0xa0?)
	/usr/local/go/src/database/sql/sql.go:1940 +0x3a
database/sql.(*DB).retry(0x3813a40?, 0xc001a79bd8)
	/usr/local/go/src/database/sql/sql.go:1566 +0x42
database/sql.(*DB).Conn(0xc001869c70, {0x25cbf28?, 0xc0002002d0?})
	/usr/local/go/src/database/sql/sql.go:1939 +0x7b
```