### PR TITLE
fixed panic due to incorrect dsn

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -184,10 +184,10 @@ func (connector *OracleConnector) WithKerberosAuth(auth configurations.KerberosA
 // Open return a new open connection
 func (driver *OracleDriver) Open(name string) (driver.Conn, error) {
 	conn, err := NewConnection(name, driver.connOption)
-	conn.cusTyp = driver.cusTyp
 	if err != nil {
 		return nil, err
 	}
+	conn.cusTyp = driver.cusTyp
 	err = conn.Open()
 	if err != nil {
 		return nil, err
@@ -551,7 +551,7 @@ func (conn *Connection) getDBServerTimeZone() {
 	}
 
 	var current time.Time
-	err := conn.QueryRowContext(context.Background(), "SELECT SYSTIMESTAMP FROM DUAL", nil).Scan(&current)
+	err := conn.QueryRowContext(context.Background(), "SELECT systimestamp FROM dual", nil).Scan(&current)
 	if err != nil {
 		conn.dbServerTimeZone = time.UTC
 	}
@@ -560,7 +560,7 @@ func (conn *Connection) getDBServerTimeZone() {
 
 func (conn *Connection) getDBTimeZone() error {
 	var result string
-	err := conn.QueryRowContext(context.Background(), "SELECT DBTIMEZONE FROM DUAL", nil).Scan(&result)
+	err := conn.QueryRowContext(context.Background(), "SELECT dbtimezone FROM dual", nil).Scan(&result)
 	// var current time.Time
 	// err := conn.QueryRowContext(context.Background(), "SELECT SYSTIMESTAMP FROM DUAL", nil).Scan(&current)
 	if err != nil {


### PR DESCRIPTION
With an invalid DSN, I got a panic with such a backtrace:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xbc2ba8]

goroutine 88 [running]:
github.com/sijms/go-ora/v2.(*OracleDriver).Open(0x1dc91a0, {0xc0000c22c0, 0x39})
	vendor/github.com/sijms/go-ora/v2/connection.go:178 +0xc8
github.com/simukti/sqldb-logger.(*connector).Connect(0xc0001941e0, {0xe788d8, 0x1e12c80})
	vendor/github.com/simukti/sqldb-logger/connector.go:21 +0x1a3
database/sql.(*DB).conn(0xc0001901a0, {0xe788d8, 0x1e12c80}, 0x1)
...
```