### PR TITLE
Fix negative interval for year to month

### DIFF
--- a/v2/converters/other_types.go
+++ b/v2/converters/other_types.go
@@ -84,7 +84,7 @@ func ConvertIntervalYM_DTY(val []byte) string {
 		return fmt.Sprintf("+%02d-%02d", years, months)
 	}
 	years = -years
-	months := val[4] - 40
+	months := 60 - val[4]
 	return fmt.Sprintf("-%02d-%02d", years, months)
 }
 

--- a/v2/converters/other_types.go
+++ b/v2/converters/other_types.go
@@ -79,10 +79,11 @@ func ConvertIntervalYM_DTY(val []byte) string {
 	*/
 	uyears := binary.BigEndian.Uint32(val)
 	years := int64(uyears) - 0x80000000
-	if years >= 0 {
+	if years >= 0 && val[4] >= 60 {
 		months := val[4] - 60
 		return fmt.Sprintf("+%02d-%02d", years, months)
 	}
+
 	years = -years
 	months := 60 - val[4]
 	return fmt.Sprintf("-%02d-%02d", years, months)
@@ -99,20 +100,22 @@ func ConvertIntervalDS_DTY(val []byte) string {
 	   nanoseconds
 	*/
 	udays := binary.BigEndian.Uint32(val)
+	uns := binary.BigEndian.Uint32(val[7:])
+
 	days := int64(udays) - 0x80000000
-	if days >= 0 {
+	ns := (int64(uns) - 0x80000000) / 1000
+
+	if days >= 0 && ns >= 0 && val[4] >= 60 && val[5] >= 60 && val[6] >= 60 {
 		hours := val[4] - 60
 		mins := val[5] - 60
 		secs := val[6] - 60
-		uns := binary.BigEndian.Uint32(val[7:])
-		ns := (int64(uns) - 0x80000000) / 1000
+
 		return fmt.Sprintf("+%02d %02d:%02d:%02d.%06d", days, hours, mins, secs, ns)
 	}
 	days = -days
 	hours := 60 - val[4]
 	mins := 60 - val[5]
 	secs := 60 - val[6]
-	uns := binary.BigEndian.Uint32(val[7:])
-	ns := -(int64(uns) - 0x80000000) / 1000
+	ns = -ns
 	return fmt.Sprintf("-%02d %02d:%02d:%02d.%06d", days, hours, mins, secs, ns)
 }

--- a/v2/converters/other_types_test.go
+++ b/v2/converters/other_types_test.go
@@ -90,6 +90,11 @@ Typ=182 Len=5: 128,0,0,0,70
 SQL> SELECT cast(TO_YMINTERVAL('00-10') as INTERVAL YEAR TO MONTH) FROM dual;
 +00-10
 
+SQL> SELECT dump(cast(TO_YMINTERVAL('-0-3') as INTERVAL YEAR TO MONTH)) FROM dual;
+Typ=182 Len=5: 128,0,0,0,57
+SQL> SELECT cast(TO_YMINTERVAL('-0-3') as INTERVAL YEAR TO MONTH) FROM dual;
+-00-03
+
 Note that heading + is expected in the string representation
 */
 
@@ -120,6 +125,10 @@ func TestIntervalYM(t *testing.T) {
 			[]byte{128, 0, 0, 0, 70},
 			"+00-10",
 		},
+		{
+			[]byte{128, 0, 0, 0, 57},
+			"-00-03",
+		},
 	}
 
 	for _, c := range cases {
@@ -146,6 +155,16 @@ Typ=183 Len=11: 128,0,0,0,70,80,90,155,58,12,8
 SQL> SELECT cast(TO_DSINTERVAL('0 10:20:30.456789') as INTERVAL DAY TO SECOND) FROM dual;
 +00 10:20:30.456789
 
+SQL> SELECT dump(cast(TO_DSINTERVAL('-0 10:20:30.456789') as INTERVAL DAY TO SECOND)) FROM dual;
+Typ=183 Len=11: 128,0,0,0,50,40,30,100,197,243,248
+SQL> SELECT cast(TO_DSINTERVAL('-0 10:20:30.456789') as INTERVAL DAY TO SECOND) FROM dual;
+-00 10:20:30.456789
+
+SQL> SELECT dump(cast(TO_DSINTERVAL('-0 10:20:30.0') as INTERVAL DAY TO SECOND)) FROM dual;
+Typ=183 Len=11: 128,0,0,0,50,40,30,128,0,0,0
+SQL> SELECT cast(TO_DSINTERVAL('-0 10:20:30.0') as INTERVAL DAY TO SECOND) FROM dual;
+-00 10:20:30.000000
+
 Note that heading + is expected in the string representation
 */
 func TestIntervalDS(t *testing.T) {
@@ -161,6 +180,14 @@ func TestIntervalDS(t *testing.T) {
 		{
 			[]byte{128, 0, 0, 0, 70, 80, 90, 155, 58, 12, 8},
 			"+00 10:20:30.456789",
+		},
+		{
+			[]byte{128, 0, 0, 0, 50, 40, 30, 100, 197, 243, 248},
+			"-00 10:20:30.456789",
+		},
+		{
+			[]byte{128, 0, 0, 0, 50, 40, 30, 128, 0, 0, 0},
+			"-00 10:20:30.000000",
 		},
 	}
 

--- a/v2/converters/other_types_test.go
+++ b/v2/converters/other_types_test.go
@@ -80,6 +80,11 @@ Typ=182 Len=5: 127,255,255,251,50
 SQL> SELECT cast(TO_YMINTERVAL('-5-10') as INTERVAL YEAR TO MONTH) FROM dual;
 -05-10
 
+SQL> SELECT dump(cast(TO_YMINTERVAL('-5-3') as INTERVAL YEAR TO MONTH)) FROM dual;
+Typ=182 Len=5: 127,255,255,251,57
+SQL> SELECT cast(TO_YMINTERVAL('-5-3') as INTERVAL YEAR TO MONTH) FROM dual;
+-05-03
+   
 SQL> SELECT dump(cast(TO_YMINTERVAL('00-10') as INTERVAL YEAR TO MONTH)) FROM dual;
 Typ=182 Len=5: 128,0,0,0,70
 SQL> SELECT cast(TO_YMINTERVAL('00-10') as INTERVAL YEAR TO MONTH) FROM dual;
@@ -106,6 +111,10 @@ func TestIntervalYM(t *testing.T) {
 		{
 			[]byte{127, 255, 255, 251, 50},
 			"-05-10",
+		},
+		{
+			[]byte{127, 255, 255, 251, 57},
+			"-05-03",
 		},
 		{
 			[]byte{128, 0, 0, 0, 70},


### PR DESCRIPTION
There is bug in formula for negative date interval year to month. It doesn't work for any value other then 10 month and it contradicts comment which states the value is "month + 60"
I've made changes to align code with date to seconds version and added test.

Also fixed case when interval is negative but year or day is zero.