### PR TITLE
Fix character set regression

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -317,11 +317,10 @@ func (conn *Connection) getDefaultStrConv() (converters.IStringConverter, error)
 	return conn.getStrConv(conn.getDefaultCharsetID())
 }
 func (conn *Connection) getStrConv(charsetID int) (converters.IStringConverter, error) {
-	if conn.cStrConv != nil && charsetID == conn.cStrConv.GetLangID() {
-		return conn.cStrConv, nil
-	}
-
 	if conn.sStrConv != nil && charsetID == conn.sStrConv.GetLangID() {
+		if conn.cStrConv != nil {
+			return conn.cStrConv, nil
+		}
 		return conn.sStrConv, nil
 	}
 


### PR DESCRIPTION
[This change](https://github.com/sijms/go-ora/commit/487451c9af0085729c95fcfb7a77932d8a3b3ef9#diff-14ca2675a55cb4d69070e5d02bbae246339ffeb8343e8a966f78d5542c18700cL288) to the `Connection.getStrConv` function in v2.8.21 caused a regression in my application.  This PR fixes that regression by restoring that function's previous logic.

Context: My application specifies `CLIENT CHARSET=UTF8` in order to send and receive UTF-8 characters to and from a US7ASCII database.  When my application calls stored procedures that use the HTP package to generate an HTTP response and then OWA.GET_PAGE to return that response, the regression causes non-ASCII UTF-8 characters to be converted to `?` characters.

(I don't actually know what the difference is between `cStrConv`, `sStrConv`, and `nStrConv`, so all I can say is that this PR works for me!)