### PR TITLE
fix query parameters incorrect parsing

### DIFF
--- a/v2/utils.go
+++ b/v2/utils.go
@@ -53,6 +53,8 @@ var (
 func refineSqlText(text string) string {
 	index := 0
 	length := len(text)
+	inSingleQuote := false
+	inDoubleQuote := false
 	skip := false
 	lineComment := false
 	textBuffer := make([]byte, 0, len(text))
@@ -73,9 +75,13 @@ func refineSqlText(text string) string {
 				skip = false
 			}
 		case '\'':
-			skip = !skip
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			}
 		case '"':
-			skip = !skip
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			}
 		case '-':
 			if !skip {
 				if index+1 < length && text[index+1] == '-' {
@@ -93,7 +99,7 @@ func refineSqlText(text string) string {
 				textBuffer = append(textBuffer, ch) // oheurtel : keep the line feed character
 			}
 		default:
-			if skip || lineComment {
+			if skip || lineComment || inSingleQuote || inDoubleQuote {
 				continue
 			}
 			textBuffer = append(textBuffer, text[index])

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -75,11 +75,11 @@ func refineSqlText(text string) string {
 				skip = false
 			}
 		case '\'':
-			if !inDoubleQuote {
+			if !skip && !inDoubleQuote {
 				inSingleQuote = !inSingleQuote
 			}
 		case '"':
-			if !inSingleQuote {
+			if !skip && !inSingleQuote {
 				inDoubleQuote = !inDoubleQuote
 			}
 		case '-':


### PR DESCRIPTION
Hi, found bug when tried to execute query with qoueted string, which contains http link.
like that: "select '"http://something"' from dual" (note single and double qoutes).
function refineSqlText which used by parseQueryParametersNames ignores order of quotation.
refineSqlText returns "select http:something from dual" and ":something" populates named parameters array.
This PR fixes that.