### PR TITLE
fix: when compress is true the size may be greater than 8

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1602,6 +1603,9 @@ func (session *Session) GetInt64(size int, compress bool, bigEndian bool) (int64
 	}
 	if size == 0 {
 		return 0, nil
+	} else if size > 8 {
+		// When compress is true, "size" may be a value greater than 8 in some cases
+		return 0, errors.New("invalid size for GetInt64: " + strconv.Itoa(size))
 	}
 	rb, err := session.read(size)
 	if err != nil {


### PR DESCRIPTION
This functionality has already been added in the v1 session code, but it is missing in v2