### PR TITLE
case-insensitive parameters matching

### DIFF
--- a/v2/command.go
+++ b/v2/command.go
@@ -1829,7 +1829,7 @@ func (stmt *Stmt) useNamedParameters() error {
 		for x := 0; x < len(names); x++ {
 			found := false
 			for _, par := range stmt.Pars {
-				if par.Name == names[x] {
+				if strings.ToLower(par.Name) == strings.ToLower(names[x]) {
 					parCollection = append(parCollection, par)
 					found = true
 					break
@@ -1858,7 +1858,7 @@ func (stmt *Stmt) useNamedParameters() error {
 			}
 			found := false
 			for _, par := range stmt.Pars {
-				if par.Name == names[x] {
+				if strings.ToLower(par.Name) == strings.ToLower(names[x]) {
 					if !repeated {
 						parCollection = append(parCollection, par)
 					}


### PR DESCRIPTION
This PR fixes an issue where using bind variables (inside statement) in a different case than their corresponding parameters in the parameter list results in the error "parameter %s is not defined in parameter list".

Problem:
When binding parameters, the comparison between bind variable names and parameter names was case-sensitive, causing failures when the cases didn't match exactly.

Solution:
Modified the parameter name comparison to be case-insensitive, ensuring consistent behavior regardless of the case used in bind variables.