### PR TITLE
ServerAddr can have spaces between the informations

### DIFF
--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -57,7 +57,7 @@ type DatabaseInfo struct {
 
 func ExtractServers(connStr string) (addresses []ServerAddr, err error) {
 	var connectionAddressRegexp *regexp.Regexp
-	connectionAddressRegexp, err = regexp.Compile(`(?i)\(\s*ADDRESS\s*=\s*(\(\s*(HOST)\s*=\s*([\w\.\-\:]+)\s*\)|\(\s*(PORT)\s*=\s*([0-9]+)\s*\)|\(\s*(COMMUNITY)\s*=\s*([\w.-]+)\s*\)|\(\s*(PROTOCOL)\s*=\s*(\w+)\s*\)\s*)+\)`)
+	connectionAddressRegexp, err = regexp.Compile(`(?i)\(\s*ADDRESS\s*=\s*(\(\s*(HOST)\s*=\s*([\w\.\-\:]+)\s*\)|\(\s*(PORT)\s*=\s*([0-9]+)\s*\)|\(\s*(COMMUNITY)\s*=\s*([\w.-]+)\s*\)|\(\s*(PROTOCOL)\s*=\s*(\w+)\s*\)\s*)+\s*\)`)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -57,7 +57,7 @@ type DatabaseInfo struct {
 
 func ExtractServers(connStr string) (addresses []ServerAddr, err error) {
 	var connectionAddressRegexp *regexp.Regexp
-	connectionAddressRegexp, err = regexp.Compile(`(?i)\(\s*ADDRESS\s*=\s*(\(\s*(HOST)\s*=\s*([\w\.\-\:]+)\s*\)|\(\s*(PORT)\s*=\s*([0-9]+)\s*\)|\(\s*(COMMUNITY)\s*=\s*([\w.-]+)\s*\)|\(\s*(PROTOCOL)\s*=\s*(\w+)\s*\)\s*)+\s*\)`)
+	connectionAddressRegexp, err = regexp.Compile(`(?i)\(\s*ADDRESS\s*=\s*(\(\s*(HOST)\s*=\s*([\w\.\-\:]+)\s*\)\s*|\(\s*(PORT)\s*=\s*([0-9]+)\s*\)\s*|\(\s*(COMMUNITY)\s*=\s*([\w.-]+)\s*\)\s*|\(\s*(PROTOCOL)\s*=\s*(\w+)\s*\)\s*)+\s*\)`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I had a interesting bug.

In the following connection string only the second address was successful parsed by the current regex. From my understanding, the fist one is also valid, which is why I changed the regex to include more whitespaces in the regex. Then it would parse both addresses successfully.
```
(DESCRIPTION = 
(ADDRESS_LIST = 
(ADDRESS = (PROTOCOL = TCP) (HOST = DB1) (PORT = 1521) )
(ADDRESS = (PROTOCOL = TCP)(HOST = DB2)(PORT = 1521))
)
)
```