### PR TITLE
connection: write warnings to stderr, not stdout

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -1258,7 +1258,7 @@ func (conn *Connection) readMsg(msgCode uint8) error {
 				}
 				if len(bty) >= 8 {
 					queryID := binary.LittleEndian.Uint64(bty[size-8:])
-					fmt.Println("query ID: ", queryID)
+					os.Stderr.WriteString(fmt.Sprintln("query ID: ", queryID))
 				}
 			}
 		}
@@ -1299,7 +1299,7 @@ func (conn *Connection) readMsg(msgCode uint8) error {
 			return err
 		}
 		if warning != nil {
-			fmt.Println(warning)
+			os.Stderr.WriteString(fmt.Sprintln(warning))
 		}
 	case 23:
 		opCode, err := session.GetByte()


### PR DESCRIPTION
writing errors / warnings / log messages to stdout is a bad practice and in our case it has caused unexpected results as we are consuming the stdout of a program which uses go-ora, and we are getting these unexpected warnings in stdout