### PR TITLE
fix: isEqualLoc always returns true even for different timezones

### DIFF
--- a/v2/utils.go
+++ b/v2/utils.go
@@ -705,5 +705,7 @@ func isEqualLoc(zone1, zone2 *time.Location) bool {
 	t := time.Now()
 	t1 := t.In(zone1)
 	t2 := t.In(zone2)
-	return t1.Equal(t2)
+	name1, offset1 := t1.Zone()
+	name2, offset2 := t2.Zone()
+	return name1 == name2 && offset1 == offset2
 }

--- a/v2/utils_test.go
+++ b/v2/utils_test.go
@@ -361,3 +361,34 @@ func TestCatchReturning(t *testing.T) {
 		t.Error(fmt.Errorf("expected true and got false"))
 	}
 }
+
+func TestIsEqualLoc(t *testing.T) {
+	testScenarios := []struct {
+		description string
+		loc1        *time.Location
+		loc2        *time.Location
+		expectEqual bool
+	}{
+		{
+			description: "Equal locations",
+			loc1:        time.FixedZone("UTC", 0),
+			loc2:        time.FixedZone("UTC", 0),
+			expectEqual: true,
+		},
+		{
+			description: "Different locations",
+			loc1:        time.FixedZone("UTC", 0),
+			loc2:        time.FixedZone("America/New_York", -5*60*60),
+			expectEqual: false,
+		},
+	}
+
+	for _, scenario := range testScenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			result := isEqualLoc(scenario.loc1, scenario.loc2)
+			if result != scenario.expectEqual {
+				t.Errorf("expected %v, got %v", scenario.expectEqual, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current implementation of `isEqualLoc` always returns true even for different timezone. @tietnhathung gave a detailed description of the issue in #686. #687 is also related.

Change the comparison to zone name and offset instead. Also added unit test.