### PR TITLE
Implemented driver.Validator interface for v2 connection

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -1350,11 +1350,18 @@ func (conn *Connection) setBad() {
 	conn.bad = true
 }
 
+// ResetSession decides responsible for resetting a connection. Part of a keepConnOnRollback condition to decide if to keep a transaction after rollback.
 func (conn *Connection) ResetSession(_ context.Context) error {
 	if conn.bad {
 		return driver.ErrBadConn
 	}
 	return nil
+}
+
+// IsValid validates if a connection has to be discarded. Part of a keepConnOnRollback condition to decide if to keep a transaction after rollback.
+func (conn *Connection) IsValid() bool {
+	// Connection is valid if it's not marked as bad and is in opened state
+	return !conn.bad && conn.State == Opened
 }
 
 func (conn *Connection) dataTypeNegotiation() error {

--- a/v2/connection_test.go
+++ b/v2/connection_test.go
@@ -1,0 +1,77 @@
+package go_ora
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+)
+
+func TestValidatorInterface(t *testing.T) {
+	// Test that Connection implements driver.Validator interface
+	var conn interface{} = &Connection{}
+	if _, ok := conn.(driver.Validator); !ok {
+		t.Error("Connection does not implement driver.Validator interface")
+	}
+}
+
+func TestSessionResetterInterface(t *testing.T) {
+	// Test that Connection implements driver.SessionResetter interface  
+	var conn interface{} = &Connection{}
+	if _, ok := conn.(driver.SessionResetter); !ok {
+		t.Error("Connection does not implement driver.SessionResetter interface")
+	}
+}
+
+func TestIsValidMethod(t *testing.T) {
+	// Create a basic connection instance
+	conn := &Connection{
+		State: Closed,
+		bad:   false,
+	}
+
+	// Test closed connection is invalid
+	if conn.IsValid() {
+		t.Error("Expected closed connection to be invalid")
+	}
+
+	// Test opened connection is valid
+	conn.State = Opened
+	if !conn.IsValid() {
+		t.Error("Expected opened connection to be valid")
+	}
+
+	// Test bad connection is invalid even when opened
+	conn.bad = true
+	if conn.IsValid() {
+		t.Error("Expected bad connection to be invalid")
+	}
+
+	// Test connection is valid when opened and not bad
+	conn.bad = false
+	conn.State = Opened
+	if !conn.IsValid() {
+		t.Error("Expected opened, non-bad connection to be valid")
+	}
+}
+
+func TestResetSessionMethod(t *testing.T) {
+	ctx := context.Background()
+
+	// Test reset session on good connection
+	conn := &Connection{
+		State: Opened,
+		bad:   false,
+	}
+
+	err := conn.ResetSession(ctx)
+	if err != nil {
+		t.Errorf("Expected no error on good connection, got: %v", err)
+	}
+
+	// Test reset session on bad connection returns ErrBadConn
+	conn.bad = true
+	err = conn.ResetSession(ctx)
+	if err != driver.ErrBadConn {
+		t.Errorf("Expected driver.ErrBadConn on bad connection, got: %v", err)
+	}
+}

--- a/v2/urowid_test.go
+++ b/v2/urowid_test.go
@@ -55,7 +55,7 @@ func TestURowid(t *testing.T) {
 	stmt._hasLONG = false
 	stmt.arrayBindCount = 0
 	dataSet := new(DataSet)
-	err := stmt.read(dataSet)
+	err := stmt.read(dataSet.currentResultSet())
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR implements the driver.Validator interface for v2 connections, allowing the Go database/sql package to return connections to the pool after transaction rollbacks instead of discarding them.

  Changes:
  - Added IsValid() bool method to check connection health
  - Added tests for validator interface implementation as well as SessionResetter

Improves performance by reducing connection churn - the keepConnOnRollback flag in Go's sql package is now true, enabling connection reuse after rollbacks when connections are still valid.

Also fixed one random test that had compilation error. 