### PR TITLE
Minor fix regarding variable scope.

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -210,9 +210,9 @@ func (session *Session) StartContext(ctx context.Context) chan struct{} {
 			case <-done:
 				return
 			default:
-				session.mu.Lock()
+				mu.Lock()
 				connected := session.Connected
-				session.mu.Unlock()
+				mu.Unlock()
 				if connected {
 					if err = session.BreakConnection(); err != nil {
 						tracer.Print("Connection Break Error: ", err)


### PR DESCRIPTION
I noticed the simultaneous use of the variable `mu` passed to the anonymous function at the moment of invocation, as well as the variable from the external scope `session.mu`.

I believe that `mu` should be used consistently throughout the entire function body. As in lines [202](https://github.com/sijms/go-ora/blob/master/v2/network/session.go#L202) and [204](https://github.com/sijms/go-ora/blob/master/v2/network/session.go#L204).

However, my knowledge of concurrency issues is so limited that my ‘correction’ may be misguided.