### PR TITLE
allow in-memory wallet to be used when opening a connection

### DIFF
--- a/examples/wallet_reader/README.md
+++ b/examples/wallet_reader/README.md
@@ -1,0 +1,153 @@
+# Wallet Reader Example
+
+This example demonstrates how to load Oracle Wallets using the `io.Reader` interface instead of file paths.
+
+## Why Use io.Reader?
+
+Using `io.Reader` provides flexibility to load wallets from various sources:
+
+- **Embedded Files**: Bundle wallets in your binary using `go:embed`
+- **Remote Sources**: Load from HTTP, S3, Google Cloud Storage, etc.
+- **Secrets Managers**: Retrieve from HashiCorp Vault, AWS Secrets Manager, etc.
+- **In-Memory**: Use wallet data stored in memory without touching disk
+- **Encrypted Storage**: Decrypt wallets on-the-fly from encrypted sources
+
+## Concurrency Safe
+
+This implementation uses `OracleConnector` with `sql.OpenDB()`, which means:
+
+- Each connector maintains its own wallet configuration
+- Multiple goroutines can use different wallets without interference
+- No global state is modified
+
+## Basic Usage
+
+```go
+import (
+    "database/sql"
+    "os"
+
+    go_ora "github.com/sijms/go-ora/v2"
+)
+
+func main() {
+    // Create a new connector - isolated from other connections
+    connector := go_ora.NewConnector(
+        "oracle://user:pass@server:1521/service?SSL=enable",
+    )
+
+    // Open wallet file (could be any io.Reader)
+    walletFile, _ := os.Open("/path/to/cwallet.sso")
+    defer walletFile.Close()
+
+    // Load wallet from reader - data is read immediately
+    connector.WithWallet(walletFile)
+
+    // Use sql.OpenDB with the connector
+    db := sql.OpenDB(connector)
+    defer db.Close()
+}
+```
+
+## Running the Example
+
+```bash
+go run main.go "oracle://user:pass@server:1521/service?SSL=enable" "/path/to/cwallet.sso"
+```
+
+## Embedded Wallet Example
+
+See `embedded_example.go` for how to embed a wallet file directly in your binary:
+
+```go
+import "embed"
+
+//go:embed wallets/cwallet.sso
+var walletFS embed.FS
+
+func ConnectWithEmbeddedWallet() (*sql.DB, error) {
+    connector := go_ora.NewConnector("oracle://user:pass@server/service?SSL=enable")
+
+    walletFile, _ := walletFS.Open("wallets/cwallet.sso")
+    defer walletFile.Close()
+
+    connector.WithWallet(walletFile)
+
+    return sql.OpenDB(connector), nil
+}
+```
+
+## Multiple Wallets in Concurrent Goroutines
+
+Each connector is independent, so you can safely use different wallets:
+
+```go
+func connectWithWallet(connStr string, walletPath string) (*sql.DB, error) {
+    connector := go_ora.NewConnector(connStr)
+
+    walletFile, err := os.Open(walletPath)
+    if err != nil {
+        return nil, err
+    }
+    defer walletFile.Close()
+
+    if err := connector.WithWallet(walletFile); err != nil {
+        return nil, err
+    }
+
+    return sql.OpenDB(connector), nil
+}
+
+// Safe to call from multiple goroutines with different wallets
+go connectWithWallet("oracle://user1:pass@server1/svc", "/path/to/wallet1/cwallet.sso")
+go connectWithWallet("oracle://user2:pass@server2/svc", "/path/to/wallet2/cwallet.sso")
+```
+
+## Advanced Examples
+
+### Loading from HTTP
+
+```go
+resp, _ := http.Get("https://secrets.example.com/wallet/cwallet.sso")
+defer resp.Body.Close()
+
+connector := go_ora.NewConnector("oracle://user:pass@server/service?SSL=enable")
+connector.WithWallet(resp.Body)
+db := sql.OpenDB(connector)
+```
+
+### Loading from In-Memory Data
+
+```go
+import "bytes"
+
+walletData := []byte{...} // Your wallet data
+reader := bytes.NewReader(walletData)
+
+connector := go_ora.NewConnector("oracle://user:pass@server/service?SSL=enable")
+connector.WithWallet(reader)
+db := sql.OpenDB(connector)
+```
+
+### Direct API Usage
+
+You can also use the configuration API directly:
+
+```go
+import "github.com/sijms/go-ora/v2/configurations"
+
+walletFile, _ := os.Open("cwallet.sso")
+defer walletFile.Close()
+
+wallet, _ := configurations.NewWalletFromReader(walletFile)
+
+// Use wallet directly with your configuration
+```
+
+## Notes
+
+- This feature supports **cwallet.sso** files only
+- The wallet data is read immediately when `WithWallet()` is called
+- The reader can be closed after `WithWallet()` returns
+- All existing wallet functionality (credential extraction, certificate handling) works the same
+- Backward compatibility is maintained - file path-based loading still works via URL parameters

--- a/v2/configurations/wallet_reader_test.go
+++ b/v2/configurations/wallet_reader_test.go
@@ -1,0 +1,98 @@
+package configurations
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// TestNewWalletFromReader verifies that NewWalletFromReader works the same as NewWallet
+func TestNewWalletFromReader(t *testing.T) {
+	// This test requires an actual wallet file to work
+	// It's primarily a compilation test to ensure the API is correct
+
+	// Create a mock reader with minimal valid wallet structure
+	// In real usage, this would be a real cwallet.sso file
+	mockData := []byte{161, 248, 78} // Magic bytes
+	reader := bytes.NewReader(mockData)
+
+	_, err := NewWalletFromReader(reader)
+	// We expect an error because this is not a complete wallet
+	// but it should not panic and should return a proper error
+	if err == nil {
+		t.Error("Expected error for incomplete wallet data, got nil")
+	}
+}
+
+// TestReadFromBytesEquivalence verifies that read() and readFromBytes() produce same results
+func TestReadFromBytesEquivalence(t *testing.T) {
+	// Skip if no test wallet file is available
+	testWalletPath := os.Getenv("TEST_WALLET_PATH")
+	if testWalletPath == "" {
+		t.Skip("Skipping test: TEST_WALLET_PATH environment variable not set")
+	}
+
+	// Test with file-based loading
+	wallet1, err := NewWallet(testWalletPath)
+	if err != nil {
+		t.Fatalf("NewWallet failed: %v", err)
+	}
+
+	// Test with reader-based loading
+	data, err := os.ReadFile(testWalletPath)
+	if err != nil {
+		t.Fatalf("Failed to read wallet file: %v", err)
+	}
+
+	reader := bytes.NewReader(data)
+	wallet2, err := NewWalletFromReader(reader)
+	if err != nil {
+		t.Fatalf("NewWalletFromReader failed: %v", err)
+	}
+
+	// Compare results
+	if len(wallet1.Certificates) != len(wallet2.Certificates) {
+		t.Errorf("Certificate count mismatch: got %d, want %d",
+			len(wallet2.Certificates), len(wallet1.Certificates))
+	}
+
+	if len(wallet1.credentials) != len(wallet2.credentials) {
+		t.Errorf("Credentials count mismatch: got %d, want %d",
+			len(wallet2.credentials), len(wallet1.credentials))
+	}
+}
+
+// TestSetWalletFromReaderErrorHandling tests error cases
+func TestNewWalletFromReaderErrorHandling(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty data",
+			data:    []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid magic bytes",
+			data:    []byte{0, 0, 0},
+			wantErr: true,
+		},
+		{
+			name:    "incomplete header",
+			data:    []byte{161, 248, 78, 54},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader(tt.data)
+			_, err := NewWalletFromReader(reader)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewWalletFromReader() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I have a multi-tenant environment where multiple users can access a service and each user has their own wallet file. I don't want to write that file to a temp location so that I can pass sit in the connection string. 

This PR adds support to pass a `io.Reader` to the connector to support this use case.