### PR TITLE
Fixed false detection of multiline comment state in utils.refineSqlTe…

### DIFF
--- a/v2/utils.go
+++ b/v2/utils.go
@@ -71,14 +71,18 @@ func refineSqlText(text string) string {
 			// bypass next character
 			continue
 		case '/':
-			if index+1 < length && text[index+1] == '*' {
-				index += 1
-				skip = true
+			if !inDoubleQuote && !inSingleQuote {
+				if index+1 < length && text[index+1] == '*' {
+					index += 1
+					skip = true
+				}
 			}
 		case '*':
-			if index+1 < length && text[index+1] == '/' {
-				index += 1
-				skip = false
+			if !inDoubleQuote && !inSingleQuote {
+				if index+1 < length && text[index+1] == '/' {
+					index += 1
+					skip = false
+				}
 			}
 		case '\'':
 			if !skip && !inDoubleQuote {


### PR DESCRIPTION
Fixed false detection of multiline comment state in utils.refineSqlText. Skip condition when current state is inSingleQuote or inDoubleQuote. Previous behavior resulted in error when query had /* in string literal and used named parameters/

Example: SELECT '/*' FROM DUAL WHERE :PARAM = 1

Error: ORA-01008: not all variables bound