### PR TITLE
Cloned character converters prevent TCP-negotiated updates in multi-charset.

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -137,12 +137,16 @@ func (connector *OracleConnector) Connect(ctx context.Context) (driver.Conn, err
 		return nil, err
 	}
 	conn.cusTyp = connector.drv.cusTyp
-	if connector.drv.sStrConv != nil {
-		conn.sStrConv = connector.drv.sStrConv.Clone()
-	}
-	if connector.drv.nStrConv != nil {
-		conn.nStrConv = connector.drv.nStrConv.Clone()
-	}
+	//"TCP negotiation for character set updates fails when multiple database connections 
+	// with varying encodings coexist in the same process, 
+	// due to the cloning of the character converter."
+	// eg. Chinese GBK and UTF8
+	// if connector.drv.sStrConv != nil {
+	// 	conn.sStrConv = connector.drv.sStrConv.Clone()
+	// }
+	// if connector.drv.nStrConv != nil {
+	// 	conn.nStrConv = connector.drv.nStrConv.Clone()
+	// }
 	if conn.connOption.Dialer == nil {
 		conn.connOption.Dialer = connector.dialer
 	}


### PR DESCRIPTION
issue:https://github.com/sijms/go-ora/issues/692
Cloned character converters prevent TCP-negotiated updates in multi-charset.
eg. Chinese GBK and UTF8