### PR TITLE
Fix null VARRAY encoding in nested UDT structs

### DIFF
--- a/v2/parameter_encode.go
+++ b/v2/parameter_encode.go
@@ -605,7 +605,15 @@ func (par *ParameterInfo) encodePrimValue(conn *Connection) error {
 				switch attrib.DataType {
 				case XMLType:
 					if attrib.cusType.isArray {
-						session.WriteFixedClr(&objectBuffer, attrib.BValue)
+						if attrib.IsNull {
+							// Null VARRAY/collection: write the null marker directly
+							// without length-prefix wrapping. WriteFixedClr would add
+							// an extra length byte (0x01) before 0xFF, which corrupts
+							// the Oracle wire format for null collections.
+							objectBuffer.Write(attrib.BValue)
+						} else {
+							session.WriteFixedClr(&objectBuffer, attrib.BValue)
+						}
 					} else {
 						objectBuffer.Write(attrib.BValue)
 					}


### PR DESCRIPTION
## Problem

When inserting a struct with null VARRAY attributes (e.g., Oracle's `MDSYS.SDO_GEOMETRY` with null `SDO_ELEM_INFO` and `SDO_ORDINATES` for point geometries), the encoded data is corrupt and Oracle returns `ORA-00600` when reading it back.

## Root Cause

In `parameter_encode.go`, when encoding a struct's child attributes, null VARRAY values go through `WriteFixedClr` which adds a length-prefix byte. For a null VARRAY marker (`0xFF`), this produces `[0x01, 0xFF]` instead of just `[0xFF]`.

Oracle expects the raw null collection marker without length-prefix wrapping.

## Fix

Check `attrib.IsNull` before calling `WriteFixedClr` for array-type attributes. When null, write `BValue` directly (which is `[0xFF]`).

**Change:** 9 lines added, 1 removed in `v2/parameter_encode.go`

## Testing

Verified with Oracle Autonomous Database using `MDSYS.SDO_GEOMETRY`:

```go
// Register SDO types
go_ora.RegisterTypeWithOwner(db, "MDSYS", "NUMBER", "SDO_ELEM_INFO_ARRAY", nil)
go_ora.RegisterTypeWithOwner(db, "MDSYS", "NUMBER", "SDO_ORDINATE_ARRAY", nil)
go_ora.RegisterTypeWithOwner(db, "MDSYS", "SDO_POINT_TYPE", "", SdoPointType{})
go_ora.RegisterTypeWithOwner(db, "MDSYS", "SDO_GEOMETRY", "", SdoGeometry{})

// Insert point (null VARRAYs) — was corrupt, now works
geom := SdoGeometry{GType: 2001, SRID: 4326, Point: SdoPointType{X: -73.9, Y: 40.7}}
obj := go_ora.NewObject("MDSYS", "SDO_GEOMETRY", geom)
db.Exec("INSERT INTO t (GEOM) VALUES (:1)", obj)

// Insert polygon (populated VARRAYs) — already worked, still works
geom2 := SdoGeometry{GType: 2003, SRID: 4326, ElemInfo: []int64{1,1003,1}, Ordinates: []float64{...}}
```

Both point and polygon geometries round-trip correctly after the fix.

## Context

This fix was developed as part of the [adbc-driver-oracle](https://github.com/jatorre/adbc-driver-oracle) project (ADBC driver for Oracle with native SDO_GEOMETRY support). The direct UDT insert path is 33% faster than using `SDO_UTIL.FROM_WKBGEOMETRY()` for geometry import.