### PR TITLE
Fix a slice allocation bug in vector.go

### DIFF
--- a/v2/vector.go
+++ b/v2/vector.go
@@ -35,7 +35,7 @@ func NewVector(array interface{}) (*Vector, error) {
 		v.Data = *value
 	case []*uint8:
 		v.format = 4
-		temp := make([]byte, len(value))
+		temp := make([]byte, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}
@@ -51,7 +51,7 @@ func NewVector(array interface{}) (*Vector, error) {
 		v.Data = *value
 	case []*float32:
 		v.format = 2
-		temp := make([]float32, len(value))
+		temp := make([]float32, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}
@@ -67,7 +67,7 @@ func NewVector(array interface{}) (*Vector, error) {
 		v.Data = *value
 	case []*float64:
 		v.format = 3
-		temp := make([]float64, len(value))
+		temp := make([]float64, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}

--- a/v3/types/vector.go
+++ b/v3/types/vector.go
@@ -58,7 +58,7 @@ func CreateVector(array interface{}) (Vector, error) {
 		v.Type = VECTOR_UINT8
 		v.data = *value
 	case []*uint8:
-		temp := make([]byte, len(value))
+		temp := make([]byte, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}
@@ -71,7 +71,7 @@ func CreateVector(array interface{}) (Vector, error) {
 		v.Type = VECTOR_FL32
 		v.data = *value
 	case []*float32:
-		temp := make([]float32, len(value))
+		temp := make([]float32, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}
@@ -84,7 +84,7 @@ func CreateVector(array interface{}) (Vector, error) {
 		v.Type = VECTOR_FL64
 		v.data = *value
 	case []*float64:
-		temp := make([]float64, len(value))
+		temp := make([]float64, 0, len(value))
 		for _, val := range value {
 			temp = append(temp, *val)
 		}


### PR DESCRIPTION
Fix a slice allocation bug where creating a Vector from a slice of pointers results in a slice with incorrect leading zero values.

The slice is initialized using make([]T, len(input)) (which fills it with zero values) and then populated using append(). This causes the actual values to be appended *after* the initial zero values. 