### PR TITLE
fix: dropped advanced_nego error

### DIFF
--- a/advanced_nego/auth_service.go
+++ b/advanced_nego/auth_service.go
@@ -88,6 +88,9 @@ func (serv *authService) readServiceData(subPacketNum int) error {
 	if status == 0xFAFF && subPacketNum > 2 {
 		// get 1 byte with header
 		_, err = comm.readUB1()
+		if err != nil {
+			return err
+		}
 		serv.serviceName, err = comm.readString()
 		if err != nil {
 			return err


### PR DESCRIPTION
This picks up a dropped `err` variable in `advanced_nego`.