### PR TITLE
fix refineSqlText: ignore quotes inside line comments (#717)

### DIFF
--- a/v2/utils.go
+++ b/v2/utils.go
@@ -85,11 +85,11 @@ func refineSqlText(text string) string {
 				}
 			}
 		case '\'':
-			if !skip && !inDoubleQuote {
+			if !skip && !lineComment && !inDoubleQuote {
 				inSingleQuote = !inSingleQuote
 			}
 		case '"':
-			if !skip && !inSingleQuote {
+			if !skip && !lineComment && !inSingleQuote {
 				inDoubleQuote = !inDoubleQuote
 			}
 		case '-':

--- a/v2/utils_test.go
+++ b/v2/utils_test.go
@@ -362,6 +362,41 @@ func TestCatchReturning(t *testing.T) {
 	}
 }
 
+// issue 717: a quote inside a "--" line comment was treated as the start of
+// a string literal, so all text after the comment was dropped
+func TestRefineSqlTextIssue717(t *testing.T) {
+	testScenarios := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "line comment with embedded single quote",
+			input:       "-- Oracle's built-in advisor\nSELECT 1 FROM DUAL",
+			expected:    "SELECT 1 FROM DUAL",
+		},
+		{
+			description: "line comment without quotes",
+			input:       "-- plain comment\nSELECT 1 FROM DUAL",
+			expected:    "SELECT 1 FROM DUAL",
+		},
+		{
+			description: "block comment with embedded single quote",
+			input:       "/* Oracle's built-in advisor */SELECT 1 FROM DUAL",
+			expected:    "SELECT 1 FROM DUAL",
+		},
+	}
+
+	for _, scenario := range testScenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			result := refineSqlText(scenario.input)
+			if result != scenario.expected {
+				t.Errorf("expected %q got %q", scenario.expected, result)
+			}
+		})
+	}
+}
+
 func TestIsEqualLoc(t *testing.T) {
 	testScenarios := []struct {
 		description string


### PR DESCRIPTION
A quote character inside a "--" line comment toggled the inSingleQuote/inDoubleQuote state, which was never reset when the comment ended at the newline. All subsequent text was then dropped from the refined SQL, breaking statement type detection and causing ORA-00900 for statements preceded by comments like:

    -- Oracle's built-in advisor
    SELECT 1 FROM DUAL

Quote characters are now ignored while inside a line comment, matching the existing behavior for block comments.

Fixes #717