### PR TITLE
fix(v3): don't read past the end of short TNS accept packets (Oracle 11g connection panic)

### DIFF
--- a/v3/network/accept_packet.go
+++ b/v3/network/accept_packet.go
@@ -44,6 +44,12 @@ func newAcceptPacketFromData(packetData []byte, config *configurations.Connectio
 	if reconAddStart != 0 && reconAddLen != 0 && uint16(len(packetData)) > (reconAddStart+reconAddLen) {
 		reconAdd = string(packetData[reconAddStart:(reconAddStart + reconAddLen)])
 	}
+	// servers speaking TNS versions below 315 (e.g. Oracle 11g) send a 32-byte
+	// accept packet without the fast-auth negotiation flags at bytes [41:45]
+	negOptions2 := uint32(0)
+	if len(packetData) >= 45 {
+		negOptions2 = binary.BigEndian.Uint32(packetData[41:])
+	}
 	pck := AcceptPacket{
 		Packet: Packet{
 			sessionCtx: &SessionContext{
@@ -58,7 +64,7 @@ func newAcceptPacketFromData(packetData []byte, config *configurations.Connectio
 				ReconAddr:           reconAdd,
 				ACFL0:               packetData[22],
 				ACFL1:               packetData[23],
-				NegotiatedOptions2:  binary.BigEndian.Uint32(packetData[41:]),
+				NegotiatedOptions2:  negOptions2,
 				SessionDataUnit:     uint32(binary.BigEndian.Uint16(packetData[12:])),
 				TransportDataUnit:   uint32(binary.BigEndian.Uint16(packetData[14:])),
 				UsingAsyncReceivers: false,

--- a/v3/network/accept_packet_test.go
+++ b/v3/network/accept_packet_test.go
@@ -1,0 +1,46 @@
+package network
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/sijms/go-ora/v3/configurations"
+)
+
+// Servers speaking TNS protocol versions below 315 (e.g. Oracle 11g) reply
+// with a 32-byte accept packet that ends after the reconnect-address fields.
+// The fast-auth negotiation flags at bytes [41:45] only exist in accept
+// packets from newer servers, so parsing must not read past the end of the
+// short form.
+func TestNewAcceptPacketFromDataShortPacket(t *testing.T) {
+	packetData := make([]byte, 32)
+	binary.BigEndian.PutUint16(packetData[0:], 32)      // packet length
+	packetData[4] = uint8(ACCEPT)                       // packet type
+	binary.BigEndian.PutUint16(packetData[8:], 314)     // protocol version
+	binary.BigEndian.PutUint16(packetData[10:], 0x0801) // negotiated options
+	binary.BigEndian.PutUint16(packetData[12:], 8192)   // session data unit
+	binary.BigEndian.PutUint16(packetData[14:], 32767)  // transport data unit
+	binary.BigEndian.PutUint16(packetData[16:], 0x7f08) // NT characteristics
+	binary.BigEndian.PutUint16(packetData[18:], 0)      // accept data length
+	binary.BigEndian.PutUint16(packetData[20:], 32)     // accept data offset
+
+	pck := newAcceptPacketFromData(packetData, &configurations.ConnectionConfig{})
+	if pck == nil {
+		t.Fatal("expected accept packet, got nil")
+	}
+	if pck.sessionCtx.Version != 314 {
+		t.Errorf("Version = %d, want 314", pck.sessionCtx.Version)
+	}
+	if pck.sessionCtx.SessionDataUnit != 8192 {
+		t.Errorf("SessionDataUnit = %d, want 8192", pck.sessionCtx.SessionDataUnit)
+	}
+	if pck.sessionCtx.NegotiatedOptions2 != 0 {
+		t.Errorf("NegotiatedOptions2 = %d, want 0 for short accept packet", pck.sessionCtx.NegotiatedOptions2)
+	}
+	if pck.sessionCtx.FastAuthEnabled {
+		t.Error("FastAuthEnabled = true, want false for short accept packet")
+	}
+	if pck.sessionCtx.EODDAFlagEnabled {
+		t.Error("EODDAFlagEnabled = true, want false for short accept packet")
+	}
+}


### PR DESCRIPTION
## Problem

v3 cannot connect to Oracle servers that speak TNS protocol versions below 315 (e.g. Oracle 11gR2). Every connection attempt panics during the handshake:

```
runtime error: slice bounds out of range [41:32]
github.com/sijms/go-ora/v3/network.newAcceptPacketFromData
    network/accept_packet.go:61
github.com/sijms/go-ora/v3/network.(*Session).readPacket
    network/session.go:987
github.com/sijms/go-ora/v3/network.(*Session).Connect
    network/session.go:560
github.com/sijms/go-ora/v3.(*Connection).OpenWithContext
    connection.go:595
```

Those servers reply with a 32-byte accept packet that ends after the reconnect-address fields at bytes [28:32]. `newAcceptPacketFromData` guards for `len(packetData) < 32`, but since c41e3eb ("add support for fast negotiation/login") it also unconditionally reads the fast-auth negotiation flags from bytes [41:45]:

```go
NegotiatedOptions2:  binary.BigEndian.Uint32(packetData[41:]),
```

so any accept packet shorter than 45 bytes crashes the driver. v2 is not affected — it never reads past offset 40, and its offset 32–40 reads are guarded by the negotiated version. The v3.0.1 tag and current master both carry the bug.

## Fix

Read `NegotiatedOptions2` only when the packet is long enough to carry it. Short packets leave it zero, so `FastAuthEnabled` and `EODDAFlagEnabled` stay `false` — the correct outcome for servers that predate fast auth.

## Testing

Added `TestNewAcceptPacketFromDataShortPacket`, which feeds a 32-byte version-314 accept packet through `newAcceptPacketFromData`. Before the fix it panics at accept_packet.go:61; with the fix it parses correctly (Version=314, SDU=8192, fast-auth flags off). `go build ./...`, `go vet ./network/`, and the existing network tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
