### PR TITLE
fix: Removed WriteFinalPacket() when a connection is already closed

### DIFF
--- a/v2/connection.go
+++ b/v2/connection.go
@@ -675,10 +675,6 @@ func (conn *Connection) Close() (err error) {
 		if err != nil {
 			tracer.Print("Logoff with error: ", err)
 		}
-		err = conn.session.WriteFinalPacket()
-		if err != nil {
-			tracer.Print("Write Final Packet With Error: ", err)
-		}
 		conn.session.Disconnect()
 		conn.session = nil
 	}

--- a/v3/connection.go
+++ b/v3/connection.go
@@ -926,10 +926,6 @@ func (conn *Connection) Close() (err error) {
 		if err != nil {
 			tracer.Print("Logoff with error: ", err)
 		}
-		err = conn.session.WriteFinalPacket()
-		if err != nil {
-			tracer.Print("Write Final Packet With Error: ", err)
-		}
 		conn.session.Disconnect()
 		conn.session = nil
 	}


### PR DESCRIPTION
We had a problem where this error would continuously spam the Oracle alertlogs :

```
TNS-12599: TNS:cryptographic checksum mismatch

NI cryptographic checksum mismatch error: 12599.
  Tns error struct:
    ns main err code: 12599
    ns secondary err code: 12656
    

  VERSION INFORMATION:
        TNS for Linux: Version 19.0.0.0.0 - Production
        Oracle Bequeath NT Protocol Adapter for Linux: Version 19.0.0.0.0 - Production
        TCP/IP NT Protocol Adapter for Linux: Version 19.0.0.0.0 - Production
TNS-12599: TNS:cryptographic checksum mismatch
    ns secondary err code: 12656
    nt main err code: 0
  Version 19.24.0.0.0
2026-08-05T08:50:06.622541+00:00
``` 

I started investigating it because it's filling up the alertlog really quickly since it's written at every request. In the end, it's due to WriteFinalPacket() called even after the connection was already closed with `conn.Logoff()`. After removing it, it works correctly and the warning is not spammed in the alertlog anymore. 

Could you please test it ? I'm using a patched version in the Telegraf image in the meantime.

Thanks a in advance!