### PR TITLE
fix(v2): support double-quotes and commas in TNS connection string parameters

### DIFF
--- a/v2/configurations/database_info.go
+++ b/v2/configurations/database_info.go
@@ -10,6 +10,8 @@ import (
 
 const defaultPort int = 1521
 
+var generalQuoteRegexp = regexp.MustCompile(`(?i)([a-z0-9_]+\s*=\s*)"([^"]*)"`)
+
 type DBAPrivilege int
 
 const (
@@ -97,6 +99,8 @@ func ExtractServers(connStr string) (addresses []ServerAddr, err error) {
 func (info *DatabaseInfo) UpdateDatabaseInfo(connStr string) (err error) {
 	connStr = strings.ReplaceAll(connStr, "\r", "")
 	connStr = strings.ReplaceAll(connStr, "\n", "")
+
+	connStr = generalQuoteRegexp.ReplaceAllString(connStr, "$1$2")
 
 	info.Servers, err = ExtractServers(connStr)
 	if err != nil {

--- a/v2/connection_string.go
+++ b/v2/connection_string.go
@@ -102,6 +102,10 @@ func BuildUrl(server string, port int, service, user, password string, options m
 		ret += "?"
 		for key, val := range options {
 			val = strings.TrimSpace(val)
+			if strings.ToUpper(key) == "CONNSTR" {
+				ret += fmt.Sprintf("%s=%s&", key, url.QueryEscape(val))
+				continue
+			}
 			for _, temp := range strings.Split(val, ",") {
 				temp = strings.TrimSpace(temp)
 				if strings.ToUpper(key) == "SERVER" {

--- a/v2/connection_string_test.go
+++ b/v2/connection_string_test.go
@@ -1,0 +1,37 @@
+package go_ora
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuildJDBC_NoCommaSplit(t *testing.T) {
+	user := "test_user"
+	password := "test_password"
+	// Connection string with commas (like a DN)
+	connStr := "(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=host)(PORT=1522))(SECURITY=(SSL_SERVER_CERT_DN=CN=adwc,O=Oracle,C=US)))"
+
+	uStr := BuildJDBC(user, password, connStr, nil)
+
+	u, err := url.Parse(uStr)
+	if err != nil {
+		t.Fatalf("Failed to parse generated URL: %v", err)
+	}
+
+	q := u.Query()
+	connStrVals := q["connStr"]
+
+	if len(connStrVals) != 1 {
+		t.Errorf("Expected 1 value for 'connStr' parameter, got %d. Values: %v", len(connStrVals), connStrVals)
+	}
+
+	if connStrVals[0] != connStr {
+		t.Errorf("Expected connStr to be unmodified, got: %s", connStrVals[0])
+	}
+
+	// Double check that it contains the commas and they are escaped in the raw query
+	if !strings.Contains(u.RawQuery, "CN%3Dadwc%2CO%3DOracle%2CC%3DUS") {
+		t.Errorf("Expected escaped commas in raw query, raw query: %s", u.RawQuery)
+	}
+}

--- a/v2/network/connect_option_test.go
+++ b/v2/network/connect_option_test.go
@@ -29,20 +29,70 @@ func TestExtractServers(t *testing.T) {
 }
 
 func TestUpdateDatabaseInfo(t *testing.T) {
-	text := `(DESCRIPTION_LIST=(LOAD_BALANCE=off)(FAILOVER=on)
+	tests := []struct {
+		name            string
+		input           string
+		expectedConnStr string
+	}{
+		{
+			name:            "Standard connection string",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service)))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service)))`,
+		},
+		{
+			name:            "Quoted ssl_server_cert_dn",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN="CN=cname,O=org,L=location")))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname,O=org,L=location)))`,
+		},
+		{
+			name:            "Unquoted ssl_server_cert_dn",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname,O=org,L=location)))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname,O=org,L=location)))`,
+		},
+		{
+			name:            "Quoted ssl_server_cert_dn with escaped parentheses",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN="CN=My \) Name")))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN=CN=My \) Name)))`,
+		},
+		{
+			name:            "Quoted service_name",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME="service_name"))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname)))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=service_name))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname)))`,
+		},
+		{
+			name: "Failover description list",
+			input: `(DESCRIPTION_LIST=(LOAD_BALANCE=off)(FAILOVER=on)
  (DESCRIPTION=(CONNECT_TIMEOUT=5)(ADDRESS=(PROTOCOL=TCP)
   (HOST=dataguard_host)(PORT=1521))
   (CONNECT_DATA=(SERVICE_NAME=SERVICE_RO)(SERVER=DEDICATED)))
  (DESCRIPTION=(CONNECT_TIMEOUT=5)(ADDRESS=(PROTOCOL=TCP)
   (HOST=active_instance)(PORT=1521))
-  (CONNECT_DATA=(SERVICE_NAME=SERVICE)(SERVER=DEDICATED))))`
-
-	text = `DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN="CN=cname,O=org,L=location")))`
-	text = `(DESCRIPTION_LIST=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host1.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName)))(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host2.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName))))`
-	op := &configurations.ConnectionConfig{}
-	err := op.UpdateDatabaseInfo(text)
-	if err != nil {
-		t.Error(err)
+  (CONNECT_DATA=(SERVICE_NAME=SERVICE)(SERVER=DEDICATED))))`,
+			expectedConnStr: `(DESCRIPTION_LIST=(LOAD_BALANCE=off)(FAILOVER=on) (DESCRIPTION=(CONNECT_TIMEOUT=5)(ADDRESS=(PROTOCOL=TCP)  (HOST=dataguard_host)(PORT=1521))  (CONNECT_DATA=(SERVICE_NAME=SERVICE_RO)(SERVER=DEDICATED))) (DESCRIPTION=(CONNECT_TIMEOUT=5)(ADDRESS=(PROTOCOL=TCP)  (HOST=active_instance)(PORT=1521))  (CONNECT_DATA=(SERVICE_NAME=SERVICE)(SERVER=DEDICATED))))`,
+		},
+		{
+			name:            "Quoted wallet info",
+			input:           `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN="CN=cname,O=org,L=location")))`,
+			expectedConnStr: `(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host.com)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=service))(SECURITY=(SSL_SERVER_CERT_DN=CN=cname,O=org,L=location)))`,
+		},
+		{
+			name:            "Multiple descriptions list",
+			input:           `(DESCRIPTION_LIST=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host1.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName)))(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host2.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName))))`,
+			expectedConnStr: `(DESCRIPTION_LIST=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host1.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName)))(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host2.domain.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ServiceName))))`,
+		},
 	}
-	t.Log(op)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			op := &configurations.ConnectionConfig{}
+			err := op.UpdateDatabaseInfo(tc.input)
+			if err != nil {
+				t.Fatalf("UpdateDatabaseInfo failed: %v", err)
+			}
+			gotConnStr := op.ConnectionData()
+			if gotConnStr != tc.expectedConnStr {
+				t.Errorf("Expected connStr:\n%s\nGot:\n%s", tc.expectedConnStr, gotConnStr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Problem

TNS connection strings can contain double-quoted strings like `ssl_server_cert_dn="CN=adwc, O=Oracle"` or `SERVICE_NAME="my_service"`.  When passed by go-ora to the database server, they can result in errors like `ORA-12564`. This occurs because go-ora either:

* Fails to parse the connection string locally (for client-side parameters it recognizes, like SERVICE_NAME, because its internal regex does not expect quotes).
* Transmits the raw connection descriptor over the wire exactly as provided, including the double quotes. The Oracle Database listener's protocol parser fails when encountering these nested double quotes inside the TNS wire packet

### Fix

This PR aligns go-ora's connection descriptor parsing and serialization behavior with the official Oracle client:

* Generalized Quote Stripping: We now strip outer double quotes from any parameter values in the connection descriptor (using the regex `(?i)([a-z0-9_]+\s*=\s*)"([^"]*)"` before performing any local parsing or wire serialization. This fixes both local client-side parsing (e.g. for quoted `SERVICE_NAME`) and wire-level protocol compatibility (e.g. for `ssl_server_cert_dn`).
* DSN Preservation: Fixed `BuildUrl`/`BuildJDBC` to prevent comma-splitting parts of the `connStr` query parameter, ensuring the connection descriptor is passed to the parser intact.

It also adds unit tests and refactors the unit test framework to improve readability and to identify testcases.

* Added unit tests to verify that BuildJDBC does not split connection strings containing commas.
* Added unit tests to TestUpdateDatabaseInfo to verify that both ssl_server_cert_dn and SERVICE_NAME wrapped in double quotes are correctly stripped and parsed.
* Added unit tests to verify that escaped parentheses (e.g. \)), which are required when quotes are stripped from values containing parentheses, are correctly parsed and preserved.

### Testing

In addition to the unit tests above:

* Wire-Format Alignment: We verified against a local TCP loopback listener that the TNS Connect Packet generated by go-ora with this patch matches the wire format of the official Oracle Instant Client (Thick mode). Both clients strip the outer double quotes and preserve escaped parentheses (e.g., `\)` remains `\)` on the wire).
* E2E Connection: Confirmed that connections to a sample Oracle Autonomous Database instance succeed, even with embedded commas in a `ssl_server_cert_dn`

Note that this patch doesn't actually add support for client-side validation like `ssl_server_cert_dn`, but rather improves connection string parsing to allow these connections to succeed.