### PR TITLE
fix(v2,v3): nil pointer panic when query result is empty (#691)

### DIFF
--- a/v2/command.go
+++ b/v2/command.go
@@ -1956,6 +1956,9 @@ func (stmt *Stmt) Query_(namedArgs []driver.NamedValue) (*DataSet, error) {
 		}
 		return nil, err
 	}
+	if dataSet == nil {
+		return nil, fmt.Errorf("go-ora: query returned no result set (connection reset)")
+	}
 	return dataSet, nil
 }
 

--- a/v2/result_set.go
+++ b/v2/result_set.go
@@ -4,11 +4,12 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/network"
-	"github.com/sijms/go-ora/v2/trace"
 	"io"
 	"reflect"
 	"strings"
+
+	"github.com/sijms/go-ora/v2/network"
+	"github.com/sijms/go-ora/v2/trace"
 )
 
 type Row []driver.Value
@@ -97,7 +98,7 @@ func (resultSet *ResultSet) Close() error {
 }
 
 func (resultSet *ResultSet) Columns() []string {
-	if len(*resultSet.cols) == 0 {
+	if resultSet.cols == nil || len(*resultSet.cols) == 0 {
 		return nil
 	}
 	ret := make([]string, len(*resultSet.cols))

--- a/v2/result_set_test.go
+++ b/v2/result_set_test.go
@@ -1,0 +1,19 @@
+package go_ora
+
+import "testing"
+
+// TestResultSetColumnsNilSafe verifies that Columns() does not panic when the
+// ResultSet is uninitialized (cols == nil). This guards against the nil-pointer
+// panic reported in issue #691, where a connection reset during _query() could
+// yield a DataSet with an uninitialized ResultSet.
+func TestResultSetColumnsNilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Columns() panicked on nil cols: %v", r)
+		}
+	}()
+	rs := ResultSet{}
+	if got := rs.Columns(); got != nil {
+		t.Errorf("expected nil columns for uninitialized ResultSet, got %v", got)
+	}
+}

--- a/v3/command.go
+++ b/v3/command.go
@@ -2066,6 +2066,9 @@ func (stmt *Stmt) Query_(namedArgs []driver.NamedValue) (*DataSet, error) {
 		}
 		return nil, err
 	}
+	if dataSet == nil {
+		return nil, fmt.Errorf("go-ora: query returned no result set (connection reset)")
+	}
 	return dataSet, nil
 }
 

--- a/v3/result_set.go
+++ b/v3/result_set.go
@@ -101,7 +101,7 @@ func (resultSet *ResultSet) Close() error {
 }
 
 func (resultSet *ResultSet) Columns() []string {
-	if len(*resultSet.cols) == 0 {
+	if resultSet.cols == nil || len(*resultSet.cols) == 0 {
 		return nil
 	}
 	ret := make([]string, len(*resultSet.cols))

--- a/v3/result_set_test.go
+++ b/v3/result_set_test.go
@@ -1,0 +1,19 @@
+package go_ora
+
+import "testing"
+
+// TestResultSetColumnsNilSafe verifies that Columns() does not panic when the
+// ResultSet is uninitialized (cols == nil). This guards against the nil-pointer
+// panic reported in issue #691, where a connection reset during _query() could
+// yield a DataSet with an uninitialized ResultSet.
+func TestResultSetColumnsNilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Columns() panicked on nil cols: %v", r)
+		}
+	}()
+	rs := ResultSet{}
+	if got := rs.Columns(); got != nil {
+		t.Errorf("expected nil columns for uninitialized ResultSet, got %v", got)
+	}
+}


### PR DESCRIPTION
## Fix for #691: Panic due to nil pointer when query result is empty

### Problem
When `Stmt._query()` returns `(nil, network.ErrConnReset)`, the recovery branch in `Query_()` calls `stmt.connection.read()`. If that read succeeds, `err` becomes `nil` but `dataSet` remains `nil`, so `Query_()` returns `(nil, nil)`. The caller then panics in `Columns()` which dereferences the nil `cols` pointer (`*[]ParameterInfo`).

### Root Cause
`_query()` discards the allocated `dataSet` on `ErrConnReset` by returning `(nil, err)`, and `Query_()` only checks `err` — not `dataSet` — before returning:

``go
dataSet, err := stmt._query()           // dataSet=nil, err=ErrConnReset
if errors.Is(err, network.ErrConnReset) {
    err = stmt.connection.read()        // err -> nil on success
    ...
}
if err != nil { ... }                   // skipped (err is nil)
return dataSet, nil                     // BUG: returns (nil, nil)
``

`ResultSet.Columns()` then panics on `len(*resultSet.cols)` when `cols` is nil.

### Fix
1. **`Query_()` (v2 & v3)** — return an explicit error instead of `(nil, nil)` when `dataSet` is nil after the reset-recovery path, so callers receive a proper error rather than a nil `driver.Rows`.
2. **`ResultSet.Columns()` (v2 & v3)** — add defense-in-depth nil guard for `cols` so an uninitialized `ResultSet` returns `nil` instead of panicking.
3. **Unit tests (v2 & v3)** — add `TestResultSetColumnsNilSafe` covering the nil-cols path without requiring an Oracle DB.

### Files Changed
- `v2/command.go` — nil-dataSet guard in `Query_()`
- `v3/command.go` — nil-dataSet guard in `Query_()`
- `v2/result_set.go` — nil-guard `cols` in `Columns()`
- `v3/result_set.go` — nil-guard `cols` in `Columns()`
- `v2/result_set_test.go` (new) — unit test
- `v3/result_set_test.go` (new) — unit test

### Verification
- `v2`: `go build ./...` OK, `go test -run TestResultSetColumnsNilSafe` passes
- `v3`: `go build ./...` OK
- Pre-existing v3 test compilation failures (stale `parameter_encode_test.go`/`bulkcopy_test.go` referencing v2 types) confirmed present on `master` and unrelated to this change.

Closes #691