### PR TITLE
fix(v3): integer overflow on 32-bit platforms (linux/386) in interval.go

### DIFF
--- a/v3/types/interval.go
+++ b/v3/types/interval.go
@@ -58,18 +58,18 @@ func (interval *Interval) Value() (interface{}, error) {
 		if len(interval.bValue) < int(MaxLenIntervalYM) {
 			return nil, fmt.Errorf("interval data length is too short")
 		}
-		year = int(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000
+		year = int(int64(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000)
 		month = int(interval.bValue[4] - 60)
 		return time.Date(year, time.Month(month), 0, 0, 0, 0, 0, time.UTC), nil
 	case INTERVALDS_DTY:
 		if len(interval.bValue) < int(MaxLenIntervalDS) {
 			return nil, fmt.Errorf("interval data length is too short")
 		}
-		day = int(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000
+		day = int(int64(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000)
 		hour = int(interval.bValue[4] - 60)
 		minute = int(interval.bValue[5] - 60)
 		second = int(interval.bValue[6] - 60)
-		mSec = int(binary.BigEndian.Uint32(interval.bValue[7:]) - 0x80000000)
+		mSec = int(int64(binary.BigEndian.Uint32(interval.bValue[7:])) - 0x80000000)
 		return time.Date(0, 0, day, hour, minute, second, mSec*1000, time.UTC), nil
 	default:
 		return nil, fmt.Errorf("unsupported type id: %d used for decoding interval", typeId)
@@ -80,7 +80,7 @@ func (interval *Interval) encode(input time.Time) error {
 	buffer := new(bytes.Buffer)
 	switch interval.dataType {
 	case INTERVALYM_DTY:
-		err := binary.Write(buffer, binary.BigEndian, uint32(input.Year()+0x80000000))
+		err := binary.Write(buffer, binary.BigEndian, uint32(int64(input.Year())+0x80000000))
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (interval *Interval) encode(input time.Time) error {
 			return err
 		}
 	case INTERVALDS_DTY:
-		err := binary.Write(buffer, binary.BigEndian, uint32(input.Day()+0x80000000))
+		err := binary.Write(buffer, binary.BigEndian, uint32(int64(input.Day())+0x80000000))
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func (interval *Interval) encode(input time.Time) error {
 		if err != nil {
 			return err
 		}
-		err = binary.Write(buffer, binary.BigEndian, uint32((input.Nanosecond()/1000)+0x80000000))
+		err = binary.Write(buffer, binary.BigEndian, uint32(int64(input.Nanosecond()/1000)+0x80000000))
 		if err != nil {
 			return err
 		}

--- a/v3/types/interval_test.go
+++ b/v3/types/interval_test.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// TestIntervalEncode verifies that Interval.encode produces the correct bytes
+// with the 0x80000000 offset. This guards against the integer overflow on
+// 32-bit platforms reported in issue #738.
+func TestIntervalEncode(t *testing.T) {
+	t.Run("YearMonth", func(t *testing.T) {
+		interval := &Interval{}
+		interval.SetDataType(INTERVALYM_DTY)
+		input := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		if err := interval.SetValue(input); err != nil {
+			t.Fatalf("encode failed: %v", err)
+		}
+		b := interval.Bytes()
+		if len(b) != 5 {
+			t.Fatalf("expected 5 bytes, got %d", len(b))
+		}
+		year := int64(binary.BigEndian.Uint32(b)) - 0x80000000
+		if year != 2026 {
+			t.Errorf("expected year=2026, got %d", year)
+		}
+		month := int(b[4]) - 60
+		if month != 5 {
+			t.Errorf("expected month=5, got %d", month)
+		}
+	})
+
+	t.Run("DaySecond", func(t *testing.T) {
+		interval := &Interval{}
+		interval.SetDataType(INTERVALDS_DTY)
+		input := time.Date(0, 0, 4, 2, 30, 15, 0, time.UTC)
+		if err := interval.SetValue(input); err != nil {
+			t.Fatalf("encode failed: %v", err)
+		}
+		b := interval.Bytes()
+		if len(b) != 11 {
+			t.Fatalf("expected 11 bytes, got %d", len(b))
+		}
+		day := int64(binary.BigEndian.Uint32(b)) - 0x80000000
+		if day != 4 {
+			t.Errorf("expected day=4, got %d", day)
+		}
+		if int(b[4])-60 != 2 {
+			t.Errorf("expected hour=2, got %d", int(b[4])-60)
+		}
+		if int(b[5])-60 != 30 {
+			t.Errorf("expected minute=30, got %d", int(b[5])-60)
+		}
+		if int(b[6])-60 != 15 {
+			t.Errorf("expected second=15, got %d", int(b[6])-60)
+		}
+	})
+}
+
+// TestIntervalDecode verifies that Interval.Value decodes the 0x80000000
+// offset correctly on all platforms (issue #738).
+func TestIntervalDecode(t *testing.T) {
+	t.Run("YearMonth", func(t *testing.T) {
+		b := make([]byte, 5)
+		binary.BigEndian.PutUint32(b, uint32(0x80000000+2026))
+		b[4] = 60 + 5
+		interval := &Interval{}
+		interval.SetDataType(INTERVALYM_DTY)
+		interval.SetBytes(b)
+		val, err := interval.Value()
+		if err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		result := val.(time.Time)
+		if result.Year() != 2026 {
+			t.Errorf("expected year=2026, got %d", result.Year())
+		}
+	})
+
+	t.Run("DaySecond", func(t *testing.T) {
+		b := make([]byte, 11)
+		binary.BigEndian.PutUint32(b, uint32(0x80000000+4))
+		b[4] = 60 + 2
+		b[5] = 60 + 30
+		b[6] = 60 + 15
+		binary.BigEndian.PutUint32(b[7:], uint32(0x80000000+0))
+		interval := &Interval{}
+		interval.SetDataType(INTERVALDS_DTY)
+		interval.SetBytes(b)
+		val, err := interval.Value()
+		if err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		result := val.(time.Time)
+		if result.Hour() != 2 || result.Minute() != 30 || result.Second() != 15 {
+			t.Errorf("expected 2:30:15, got %d:%d:%d",
+				result.Hour(), result.Minute(), result.Second())
+		}
+	})
+}


### PR DESCRIPTION
## Fix for #738: Build failure due to integer overflow on linux/386

### Problem
On 32-bit platforms (`linux/386`), `int` is 32 bits and the constant `0x80000000` (2147483648) overflows `int`, causing a build failure:

```
types/interval.go:61:58: 0x80000000 (untyped int constant 2147483648) overflows int
types/interval.go:68:57: 0x80000000 (untyped int constant 2147483648) overflows int
types/interval.go:83:69: 0x80000000 (untyped int constant 2147483648) overflows int
types/interval.go:92:68: 0x80000000 (untyped int constant 2147483648) overflows int
types/interval.go:108:81: 0x80000000 (untyped int constant 2147483648) overflows int
```

### Root Cause
`v3/types/interval.go` uses `0x80000000` as an offset for Oracle's interval encoding (signed values stored as unsigned). The constant was used directly in `int` arithmetic:

**Decode (line 61):**
``go
year = int(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000  // int - 0x80000000 overflows on 32-bit
``

**Encode (line 83):**
``go
uint32(input.Year() + 0x80000000)  // int + 0x80000000 overflows on 32-bit
``

### Fix
Perform the `0x80000000` offset arithmetic in `int64` before converting back to `int` (decode) or `uint32` (encode), so the constant is interpreted as an `int64` value:

**Decode:**
``go
year = int(int64(binary.BigEndian.Uint32(interval.bValue)) - 0x80000000)
``

**Encode:**
``go
uint32(int64(input.Year()) + 0x80000000)
``

All 6 occurrences in `v3/types/interval.go` are fixed (lines 61, 68, 72, 83, 92, 108).

### Files Changed
- `v3/types/interval.go` — use `int64` arithmetic for `0x80000000` offset (6 sites)
- `v3/types/interval_test.go` (new) — `TestIntervalEncode` and `TestIntervalDecode` verifying the offset arithmetic

### Verification
- `go build ./...` (windows/amd64) OK
- `GOOS=linux GOARCH=386 go build ./...` OK (previously failed)
- `GOOS=linux GOARCH=386 go test -c ./types/` OK (test compiles on 386)
- `go test -run TestInterval ./types/` passes
- v2 already uses `int64` arithmetic in its converters (no change needed)

Closes #738