### PR TITLE
fix(v2,v3): ColumnTypeScanType returns nil for CLOB/BLOB in INLINE LOB mode

### DIFF
--- a/v2/result_set.go
+++ b/v2/result_set.go
@@ -4,11 +4,12 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"github.com/sijms/go-ora/v2/network"
-	"github.com/sijms/go-ora/v2/trace"
 	"io"
 	"reflect"
 	"strings"
+
+	"github.com/sijms/go-ora/v2/network"
+	"github.com/sijms/go-ora/v2/trace"
 )
 
 type Row []driver.Value
@@ -162,10 +163,14 @@ func (resultSet *ResultSet) ColumnTypeScanType(index int) reflect.Type {
 	case CHAR, NCHAR:
 		fallthrough
 	case OCIClobLocator:
+		fallthrough
+	case LongVarChar:
 		return tyString
 	case RAW:
 		fallthrough
 	case OCIBlobLocator, OCIFileLocator:
+		fallthrough
+	case LongRaw, LongVarRaw:
 		return tyBytes
 	case DATE, TIMESTAMP:
 		fallthrough

--- a/v2/result_set_test.go
+++ b/v2/result_set_test.go
@@ -1,0 +1,33 @@
+package go_ora
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestColumnTypeScanTypeInlineLOB verifies that ColumnTypeScanType returns
+// the correct Go type for columns whose DataType was mutated to LongVarChar
+// or LongRaw by writeDefine() when LOB mode is INLINE. This is issue #719.
+func TestColumnTypeScanTypeInlineLOB(t *testing.T) {
+	cases := []struct {
+		name     string
+		dataType TNSType
+		want     reflect.Type
+	}{
+		{"CLOB_inline", LongVarChar, tyString},
+		{"BLOB_inline", LongRaw, tyBytes},
+		{"LongVarRaw", LongVarRaw, tyBytes},
+		{"CLOB_locator", OCIClobLocator, tyString},
+		{"BLOB_locator", OCIBlobLocator, tyBytes},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cols := &[]ParameterInfo{{DataType: c.dataType}}
+			rs := ResultSet{cols: cols}
+			got := rs.ColumnTypeScanType(0)
+			if got != c.want {
+				t.Errorf("ColumnTypeScanType(%v) = %v, want %v", c.dataType, got, c.want)
+			}
+		})
+	}
+}

--- a/v3/result_set.go
+++ b/v3/result_set.go
@@ -167,10 +167,14 @@ func (resultSet *ResultSet) ColumnTypeScanType(index int) reflect.Type {
 	case types.CHAR, types.NCHAR:
 		fallthrough
 	case types.OCIClobLocator:
+		fallthrough
+	case types.LongVarChar:
 		return types.TyString
 	case types.RAW:
 		fallthrough
 	case types.OCIBlobLocator, types.OCIFileLocator:
+		fallthrough
+	case types.LongRaw, types.LongVarRaw:
 		return types.TyBytes
 	case types.DATE, types.TIMESTAMP:
 		fallthrough

--- a/v3/result_set_test.go
+++ b/v3/result_set_test.go
@@ -1,0 +1,37 @@
+package go_ora
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sijms/go-ora/v3/types"
+)
+
+// TestColumnTypeScanTypeInlineLOB verifies that ColumnTypeScanType returns
+// the correct Go type for columns whose DataType was mutated to LongVarChar
+// or LongRaw by writeDefine() when LOB mode is INLINE. This is issue #719.
+func TestColumnTypeScanTypeInlineLOB(t *testing.T) {
+	cases := []struct {
+		name     string
+		dataType uint16
+		want     reflect.Type
+	}{
+		{"CLOB_inline", types.LongVarChar, types.TyString},
+		{"BLOB_inline", types.LongRaw, types.TyBytes},
+		{"LongVarRaw", types.LongVarRaw, types.TyBytes},
+		{"CLOB_locator", types.OCIClobLocator, types.TyString},
+		{"BLOB_locator", types.OCIBlobLocator, types.TyBytes},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			col := ParameterInfo{}
+			col.DataType = c.dataType
+			cols := &[]ParameterInfo{col}
+			rs := ResultSet{cols: cols}
+			got := rs.ColumnTypeScanType(0)
+			if got != c.want {
+				t.Errorf("ColumnTypeScanType(%v) = %v, want %v", c.dataType, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Fix for #719: `ColumnTypeScanType()` returns `nil` for CLOB/BLOB when LOB mode is INLINE

### Problem
When LOB fetch mode is `INLINE` (the default), `writeDefine()` mutates the column `DataType` in-place on `stmt.columns`:
- `OCIClobLocator` -> `LongVarChar`
- `OCIBlobLocator` -> `LongRaw`

`ColumnTypeScanType()` had cases for `OCIClobLocator`/`OCIBlobLocator` but **no cases** for `LongVarChar`/`LongRaw`/`LongVarRaw`, so it fell through to `default: return nil`. This caused panics in ORMs, code generators, and generic row-scanning utilities that rely on `ScanType()` to determine the Go type for scanning.

### Root Cause
``go
// v2/result_set.go (before fix)
case OCIClobLocator:
    return tyString
case RAW:
    fallthrough
case OCIBlobLocator, OCIFileLocator:
    return tyBytes
// ... no case for LongVarChar or LongRaw -> default: return nil
``

### Fix
Add `LongVarChar` -> `tyString` and `LongRaw`/`LongVarRaw` -> `tyBytes` cases to `ColumnTypeScanType()` in both v2 and v3:

``go
// v2/result_set.go (after fix)
case OCIClobLocator:
    fallthrough
case LongVarChar:
    return tyString
case RAW:
    fallthrough
case OCIBlobLocator, OCIFileLocator:
    fallthrough
case LongRaw, LongVarRaw:
    return tyBytes
``

### Files Changed
- `v2/result_set.go` — add `LongVarChar`, `LongRaw`, `LongVarRaw` cases to `ColumnTypeScanType()`
- `v3/result_set.go` — same fix using `types.LongVarChar` etc.
- `v2/result_set_test.go` (new) — `TestColumnTypeScanTypeInlineLOB` unit test
- `v3/result_set_test.go` (new) — `TestColumnTypeScanTypeInlineLOB` unit test

### Verification
- `v2`: `go build ./...` OK, `go test -run TestColumnTypeScanTypeInlineLOB` passes
- `v2`: `GOOS=linux GOARCH=386 go build ./...` OK
- `v3`: `go build ./...` OK, test passes (pre-existing stale test files excluded)
- Test covers both mutated (INLINE) types and original (locator) types

Closes #719