### PR TITLE
fix(v2,v3): support type aliases in parameter encoding

### DIFF
--- a/v2/parameter_encode.go
+++ b/v2/parameter_encode.go
@@ -49,6 +49,22 @@ func (par *ParameterInfo) setDataType(conn *Connection, goType reflect.Type, dat
 	case tyBytes:
 		par.DataType = RAW
 		return nil
+	default:
+		// handle type aliases (e.g. type StringAlias string) by checking
+		// the underlying Kind when exact type identity didn't match (#699)
+		switch goType.Kind() {
+		case reflect.String:
+			par.DataType = NCHAR
+			par.CharsetForm = 1
+			par.ContFlag = 16
+			par.CharsetID = conn.getDefaultCharsetID()
+			return nil
+		case reflect.Slice:
+			if goType.Elem().Kind() == reflect.Uint8 {
+				par.DataType = RAW
+				return nil
+			}
+		}
 	}
 	// 3- call getValue
 	vData, err := getValue(data)

--- a/v2/parameter_encode_alias_test.go
+++ b/v2/parameter_encode_alias_test.go
@@ -1,0 +1,33 @@
+package go_ora
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSetDataTypeTypeAlias verifies that setDataType handles type aliases
+// (e.g. type StringAlias string) by falling back to the underlying Kind.
+// This is issue #699.
+func TestSetDataTypeTypeAlias(t *testing.T) {
+	type StringAlias string
+	type BytesAlias []byte
+
+	conn := &Connection{tcpNego: &TCPNego{}}
+	par := &ParameterInfo{}
+	aliasType := reflect.TypeOf(StringAlias(""))
+	if err := par.setDataType(conn, aliasType, StringAlias("")); err != nil {
+		t.Fatalf("setDataType failed for string alias: %v", err)
+	}
+	if par.DataType != NCHAR {
+		t.Errorf("string alias: expected DataType=NCHAR, got %v", par.DataType)
+	}
+
+	par2 := &ParameterInfo{}
+	bytesType := reflect.TypeOf(BytesAlias(nil))
+	if err := par2.setDataType(conn, bytesType, BytesAlias(nil)); err != nil {
+		t.Fatalf("setDataType failed for bytes alias: %v", err)
+	}
+	if par2.DataType != RAW {
+		t.Errorf("bytes alias: expected DataType=RAW, got %v", par2.DataType)
+	}
+}

--- a/v3/connection.go
+++ b/v3/connection.go
@@ -1767,7 +1767,21 @@ func (conn *Connection) GetParameterCoder(input interface{}) (parameter_coder.Or
 		if coder, ok := conn.goTypeCoder[input]; ok {
 			return coder.Copy(), nil
 		}
-
+		// handle type aliases (e.g. type StringAlias string) by falling
+		// back to the underlying Kind when exact type identity didn't
+		// match a registered coder (#699)
+		switch input.Kind() {
+		case reflect.String:
+			if coder, ok := conn.goTypeCoder[types.TyString]; ok {
+				return coder.Copy(), nil
+			}
+		case reflect.Slice:
+			if input.Elem().Kind() == reflect.Uint8 {
+				if coder, ok := conn.goTypeCoder[types.TyBytes]; ok {
+					return coder.Copy(), nil
+				}
+			}
+		}
 		return nil, fmt.Errorf("no parameter coder registered for go type %s", input.String())
 	case string:
 		if coder, ok := conn.nameTypeCoder[strings.ToUpper(input)]; ok {

--- a/v3/parameter_encode_alias_test.go
+++ b/v3/parameter_encode_alias_test.go
@@ -1,0 +1,40 @@
+package go_ora
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sijms/go-ora/v3/parameter_coder"
+	"github.com/sijms/go-ora/v3/types"
+)
+
+// TestGetParameterCoderTypeAlias verifies that GetParameterCoder handles
+// type aliases (e.g. type StringAlias string) by falling back to the
+// underlying Kind. This is issue #699.
+func TestGetParameterCoderTypeAlias(t *testing.T) {
+	type StringAlias string
+	type BytesAlias []byte
+
+	conn := &Connection{
+		goTypeCoder: map[reflect.Type]parameter_coder.OracleParameterCoder{
+			types.TyString: &parameter_coder.StringParameter{},
+			types.TyBytes:  &parameter_coder.RawParameter{},
+		},
+	}
+
+	coder, err := conn.GetParameterCoder(reflect.TypeOf(StringAlias("")))
+	if err != nil {
+		t.Fatalf("GetParameterCoder failed for string alias: %v", err)
+	}
+	if coder == nil {
+		t.Fatal("expected non-nil coder for string alias")
+	}
+
+	coder2, err := conn.GetParameterCoder(reflect.TypeOf(BytesAlias(nil)))
+	if err != nil {
+		t.Fatalf("GetParameterCoder failed for bytes alias: %v", err)
+	}
+	if coder2 == nil {
+		t.Fatal("expected non-nil coder for bytes alias")
+	}
+}


### PR DESCRIPTION
## Fix for #699: `unsupported go type` on type alias

### Problem
Passing a value of a type alias (e.g. `type StringAlias string`) caused an `unsupported go type` error because the type switch in `setDataType` / `GetParameterCoder` only matched exact `reflect.Type` identity, not the underlying `Kind`.

``go
type StringAlias string
// db.Query("INSERT ...", StringAlias("hello")) -> error: unsupported go type: StringAlias
``

### Root Cause
**v2** `parameter_encode.go` `setDataType()`: the `switch goType` only had cases for `tyString`, `tyBytes`, etc. (exact `reflect.Type` matches). A named type with `Kind() == reflect.String` didn't match any case and fell through to `default: return fmt.Errorf("unsupported go type: %v", goType.Name())`.

**v3** `connection.go` `GetParameterCoder()`: the `conn.goTypeCoder[input]` map lookup failed for the same reason — the alias type wasn't registered.

### Fix
**v2**: Added a `default` branch to the type switch in `setDataType()` that falls back to `goType.Kind()`:
- `reflect.String` -> `NCHAR` (same as `tyString`)
- `reflect.Slice` of `uint8` -> `RAW` (same as `tyBytes`)

**v3**: Added a Kind-based fallback in `GetParameterCoder()` after the exact map lookup fails:
- `reflect.String` -> `goTypeCoder[types.TyString]`
- `reflect.Slice` of `uint8` -> `goTypeCoder[types.TyBytes]`

### Files Changed
- `v2/parameter_encode.go` — add Kind-based fallback in `setDataType()`
- `v3/connection.go` — add Kind-based fallback in `GetParameterCoder()`
- `v2/parameter_encode_alias_test.go` (new) — `TestSetDataTypeTypeAlias`
- `v3/parameter_encode_alias_test.go` (new) — `TestGetParameterCoderTypeAlias`

### Verification
- `v2`: `go build ./...` OK, `go test -run TestSetDataTypeTypeAlias` passes
- `v2`: `GOOS=linux GOARCH=386 go build ./...` OK
- `v3`: `go build ./...` OK, `go test -run TestGetParameterCoderTypeAlias` passes

Closes #699