### PR TITLE
fix(v2,v3): data race on session.conn when context canceled during connect

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -343,7 +343,10 @@ func (session *Session) negotiate() {
 
 	if tlsConfig := connOption.TLSConfig; tlsConfig != nil {
 		tlsConfig.ServerName = host.Addr
-		session.sslConn = tls.Client(session.conn, tlsConfig)
+		sslConn := tls.Client(session.conn, tlsConfig)
+		session.mu.Lock()
+		session.sslConn = sslConn
+		session.mu.Unlock()
 		return
 	}
 
@@ -365,7 +368,10 @@ func (session *Session) negotiate() {
 	if !connOption.SSLVerify {
 		config.InsecureSkipVerify = true
 	}
-	session.sslConn = tls.Client(session.conn, config)
+	sslConn := tls.Client(session.conn, config)
+	session.mu.Lock()
+	session.sslConn = sslConn
+	session.mu.Unlock()
 }
 
 func (session *Session) ResetBreak() {
@@ -538,11 +544,19 @@ func (session *Session) Connect(ctx context.Context) error {
 			return errors.New("no available servers to connect to")
 		}
 		addr := host.NetworkAddr()
+		var conn net.Conn
 		if len(session.Context.connConfig.UnixAddress) > 0 {
-			session.conn, err = dialer.DialContext(ctx, "unix", session.Context.connConfig.UnixAddress)
+			conn, err = dialer.DialContext(ctx, "unix", session.Context.connConfig.UnixAddress)
 		} else {
-			session.conn, err = dialer.DialContext(ctx, "tcp", addr)
+			conn, err = dialer.DialContext(ctx, "tcp", addr)
 		}
+		// publish conn under the mutex to avoid a data race with
+		// Disconnect() which may be called concurrently by the
+		// StartContext watchdog when the context is canceled during
+		// connection establishment (#736)
+		session.mu.Lock()
+		session.conn = conn
+		session.mu.Unlock()
 
 		if err != nil {
 			session.tracer.Printf("using: %s ..... [FAILED]", addr)

--- a/v2/network/session_race_test.go
+++ b/v2/network/session_race_test.go
@@ -1,0 +1,54 @@
+package network
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sijms/go-ora/v2/configurations"
+	"github.com/sijms/go-ora/v2/trace"
+)
+
+// TestConnectDisconnectRace verifies that Session.Connect and
+// Session.Disconnect do not race on session.conn when the context is
+// canceled during connection establishment. Run with -race.
+// See issue #736.
+func TestConnectDisconnectRace(t *testing.T) {
+	connOption := &configurations.ConnectionConfig{
+		DatabaseInfo: configurations.DatabaseInfo{
+			Servers: []configurations.ServerAddr{
+				{Addr: "192.0.2.1", Port: 1521}, // TEST-NET-1: TCP handshake never completes
+			},
+			ServiceName: "svc",
+		},
+		SessionInfo: configurations.SessionInfo{
+			SessionDataUnitSize:   0xFFFF,
+			TransportDataUnitSize: 0xFFFF,
+		},
+	}
+
+	for i := 0; i < 5; i++ {
+		session := NewSession(connOption, trace.NilTracer())
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// goroutine 1: Connect (writes session.conn)
+		go func() {
+			defer wg.Done()
+			_ = session.Connect(ctx)
+		}()
+
+		// goroutine 2: wait for ctx deadline then Disconnect (reads session.conn)
+		go func() {
+			defer wg.Done()
+			<-ctx.Done()
+			session.Disconnect()
+		}()
+
+		wg.Wait()
+		cancel()
+	}
+}

--- a/v3/network/session.go
+++ b/v3/network/session.go
@@ -317,7 +317,10 @@ func (session *Session) negotiate() {
 
 	if tlsConfig := connOption.TLSConfig; tlsConfig != nil {
 		tlsConfig.ServerName = host.Addr
-		session.sslConn = tls.Client(session.conn, tlsConfig)
+		sslConn := tls.Client(session.conn, tlsConfig)
+		session.mu.Lock()
+		session.sslConn = sslConn
+		session.mu.Unlock()
 		return
 	}
 
@@ -339,7 +342,10 @@ func (session *Session) negotiate() {
 	if !connOption.SSLVerify {
 		config.InsecureSkipVerify = true
 	}
-	session.sslConn = tls.Client(session.conn, config)
+	sslConn := tls.Client(session.conn, config)
+	session.mu.Lock()
+	session.sslConn = sslConn
+	session.mu.Unlock()
 }
 
 func (session *Session) ResetBreak() {
@@ -512,11 +518,19 @@ func (session *Session) Connect(ctx context.Context) error {
 			return errors.New("no available servers to connect to")
 		}
 		addr := host.NetworkAddr()
+		var conn net.Conn
 		if len(session.Context.connConfig.UnixAddress) > 0 {
-			session.conn, err = dialer.DialContext(ctx, "unix", session.Context.connConfig.UnixAddress)
+			conn, err = dialer.DialContext(ctx, "unix", session.Context.connConfig.UnixAddress)
 		} else {
-			session.conn, err = dialer.DialContext(ctx, "tcp", addr)
+			conn, err = dialer.DialContext(ctx, "tcp", addr)
 		}
+		// publish conn under the mutex to avoid a data race with
+		// Disconnect() which may be called concurrently by the
+		// StartContext watchdog when the context is canceled during
+		// connection establishment (#736)
+		session.mu.Lock()
+		session.conn = conn
+		session.mu.Unlock()
 
 		if err != nil {
 			session.tracer.Printf("using: %s ..... [FAILED]", addr)

--- a/v3/network/session_race_test.go
+++ b/v3/network/session_race_test.go
@@ -1,0 +1,54 @@
+package network
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sijms/go-ora/v3/configurations"
+	"github.com/sijms/go-ora/v3/trace"
+)
+
+// TestConnectDisconnectRace verifies that Session.Connect and
+// Session.Disconnect do not race on session.conn when the context is
+// canceled during connection establishment. Run with -race.
+// See issue #736.
+func TestConnectDisconnectRace(t *testing.T) {
+	connOption := &configurations.ConnectionConfig{
+		DatabaseInfo: configurations.DatabaseInfo{
+			Servers: []configurations.ServerAddr{
+				{Addr: "192.0.2.1", Port: 1521}, // TEST-NET-1: TCP handshake never completes
+			},
+			ServiceName: "svc",
+		},
+		SessionInfo: configurations.SessionInfo{
+			SessionDataUnitSize:   0xFFFF,
+			TransportDataUnitSize: 0xFFFF,
+		},
+	}
+
+	for i := 0; i < 5; i++ {
+		session := NewSession(connOption, trace.NilTracer())
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// goroutine 1: Connect (writes session.conn)
+		go func() {
+			defer wg.Done()
+			_ = session.Connect(ctx)
+		}()
+
+		// goroutine 2: wait for ctx deadline then Disconnect (reads session.conn)
+		go func() {
+			defer wg.Done()
+			<-ctx.Done()
+			session.Disconnect()
+		}()
+
+		wg.Wait()
+		cancel()
+	}
+}


### PR DESCRIPTION
## Fix for #736: Data race on session.conn when context canceled during connection establishment

### Problem
When a `context` was canceled while `Session.Connect` was still inside `DialContext`, the `StartContext` watchdog goroutine called `Session.Disconnect()` concurrently with `Connect()` assigning `session.conn`. The assignment in `Connect()` was not synchronized with the read in `Disconnect()` (which takes `session.mu`), so `-race` reported a data race.

The same shape existed for `session.sslConn`: assigned unlocked in `negotiate()`, read under the mutex in `Disconnect()`.

### Root Cause
``go
// session.go Connect() — WRITE, unlocked
session.conn, err = dialer.DialContext(ctx, "tcp", addr)  // no mutex

// session.go Disconnect() — READ, locked
func (session *Session) Disconnect() {
    session.mu.Lock()
    defer session.mu.Unlock()
    if session.conn != nil {  // under mutex
``

The `StartContext` watchdog goroutine (line 222) has an `else` branch that fires when the session is **not yet** connected — i.e. exactly during establishment — and calls `WriteFinalPacket()` and `Disconnect()` while `Connect()` is still building the session. This branch was not covered by the v2.8.15 fix for #518/#552 (which fixed the `Connected == true` branch).

### Fix
Dial into a local variable and publish `session.conn` under `session.mu` in `Connect()`. Apply the same treatment to `session.sslConn` in both branches of `negotiate()`.

``go
// before (racy):
session.conn, err = dialer.DialContext(ctx, "tcp", addr)

// after (safe):
conn, err := dialer.DialContext(ctx, "tcp", addr)
session.mu.Lock()
session.conn = conn
session.mu.Unlock()
``

### Files Changed
- `v2/network/session.go` — publish `session.conn` under mutex in `Connect()`, publish `session.sslConn` under mutex in `negotiate()` (2 branches)
- `v3/network/session.go` — same 3 sites
- `v2/network/session_race_test.go` (new) — `TestConnectDisconnectRace`
- `v3/network/session_race_test.go` (new) — `TestConnectDisconnectRace`

### Verification
- `v2`: `go build ./...` OK, `GOOS=linux GOARCH=386 go build ./...` OK
- `v2`: `go test -race -run TestConnectDisconnectRace ./network/ -count=5` passes (no race detected)
- `v2`: `go test -race ./network/` passes (full network package)
- `v3`: `go build ./...` OK
- `v3`: `go test -race -run TestConnectDisconnectRace ./network/ -count=5` passes (no race detected)

The test dials a non-routable address (TEST-NET-1 `192.0.2.1`) with a 50ms deadline so the context fires during `DialContext`, exercising the exact race window described in the issue.

Closes #736