### PR TITLE
fix(v2): CLOB data corruption — putString encodes as UTF-16BE instead of charsetID

### DIFF
--- a/v2/lob.go
+++ b/v2/lob.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"go/types"
-
-	"github.com/sijms/go-ora/v2/converters"
 )
 
 type Clob struct {
@@ -146,19 +144,9 @@ func (lob *Lob) putString(data string) error {
 	conn := lob.connection
 	conn.tracer.Printf("Put Lob String: %d character", int64(len([]rune(data))))
 	lob.initialize()
-	var strConv converters.IStringConverter
-	if lob.variableWidthChar() {
-		if conn.dBVersion.Number < 10200 && lob.littleEndianClob() {
-			strConv, _ = conn.getStrConv(2002)
-		} else {
-			strConv, _ = conn.getStrConv(2000)
-		}
-	} else {
-		var err error
-		strConv, err = conn.getStrConv(lob.charsetID)
-		if err != nil {
-			return err
-		}
+	strConv, err := conn.getStrConv(lob.charsetID)
+	if err != nil {
+		return err
 	}
 	lobData := strConv.Encode(data)
 	// lob.size = int64(len([]rune(data)))
@@ -168,7 +156,7 @@ func (lob *Lob) putString(data string) error {
 	lob.writeOp(0x40)
 	lob.connection.session.PutBytes(0xE)
 	lob.connection.session.PutClr(lobData)
-	err := lob.connection.session.Write()
+	err = lob.connection.session.Write()
 	if err != nil {
 		return err
 	}

--- a/v2/value_setter.go
+++ b/v2/value_setter.go
@@ -3,11 +3,12 @@ package go_ora
 import (
 	"database/sql"
 	"fmt"
-	"github.com/sijms/go-ora/v2/converters"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sijms/go-ora/v2/converters"
 )
 
 // set null value from supported types
@@ -431,18 +432,9 @@ func setLob(value reflect.Value, input Lob) error {
 		return setNull(value)
 	}
 	getStrConv := func() (converters.IStringConverter, error) {
-		var ret converters.IStringConverter
-		if input.variableWidthChar() {
-			if conn.dBVersion.Number < 10200 && input.littleEndianClob() {
-				ret, _ = conn.getStrConv(2002)
-			} else {
-				ret, _ = conn.getStrConv(2000)
-			}
-		} else {
-			ret, err = conn.getStrConv(input.charsetID)
-			if err != nil {
-				return nil, err
-			}
+		ret, err := conn.getStrConv(input.charsetID)
+		if err != nil {
+			return nil, err
 		}
 		return ret, nil
 	}


### PR DESCRIPTION
## Fix for #733: CLOB data corruption when variableWidthChar() is true

### Problem
`Lob.putString()` used `variableWidthChar()` to decide the encoding for CLOB data. When the server set the variable-width flag (byte[6] bit 7) — which it does for AL32UTF8 databases — `putString` encoded the string as **UTF-16BE** (LangID 2000) regardless of the CLOB's declared charset.

This created a mismatch: the CLOB charset metadata said AL32UTF8 (870) but the bytes were UTF-16BE. On read-back, the data was decoded as UTF-8, producing garbled text.

```
Original: "status: 400|400 Bad Request"
Stored (UTF-16BE): 0x73 0x74 0x61 0x74 0x75 0x73 0x3A 0x20 ...
Read back (decoded as UTF-8): "獴慴畢㨠㐰ぼ..." (garbled CJK)
```

### Root Cause
``go
// lob.go putString() — BEFORE (buggy)
if lob.variableWidthChar() {
    strConv, _ = conn.getStrConv(2000)  // UTF-16BE — WRONG
} else {
    strConv, err = conn.getStrConv(lob.charsetID)  // correct
}
``

The `variableWidthChar()` flag indicates whether the CLOB's character set is variable-width (e.g. UTF-8). This does **not** mean the data should be encoded as UTF-16.

### Fix
Always use `lob.charsetID` for encoding in `putString()`, and always use `input.charsetID` for decoding in `value_setter.go`. This ensures write and read are symmetric and match the CLOB's declared charset.

``go
// lob.go putString() — AFTER (fixed)
strConv, err := conn.getStrConv(lob.charsetID)
``

### Files Changed
- `v2/lob.go` — `putString()`: always use `lob.charsetID`
- `v2/value_setter.go` — read path: always use `input.charsetID`

### Notes
- v3 already uses charsetID-based encoding (`variableWidthChar` is commented out in `v3/lob.go`), so no v3 change is needed
- The `variableWidthChar()` and `littleEndianClob()` methods are now unused but retained for potential future use

### Verification
- `v2`: `go build ./...` OK
- `v2`: `GOOS=linux GOARCH=386 go build ./...` OK

Closes #733