### PR TITLE
fix(v2,v3): panic on negative size in GetInt64 during RAC switchover

### DIFF
--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -1311,7 +1311,7 @@ func (session *Session) GetInt64(size int, compress bool, bigEndian bool) (int64
 	}
 	if size == 0 {
 		return 0, nil
-	} else if size > 8 {
+	} else if size < 0 || size > 8 {
 		// When compress is true, "size" may be a value greater than 8 in some cases
 		return 0, errors.New("invalid size for GetInt64: " + strconv.Itoa(size))
 	}

--- a/v2/network/session_getint64_test.go
+++ b/v2/network/session_getint64_test.go
@@ -1,0 +1,18 @@
+package network
+
+import (
+	"testing"
+)
+
+// TestGetInt64NegativeSize verifies that GetInt64 returns an error
+// instead of panicking when size is negative. This can happen during
+// RAC switchover when the connection stream is corrupted.
+// See issue #714.
+func TestGetInt64NegativeSize(t *testing.T) {
+	session := NewSessionWithInputBufferForDebug(nil)
+
+	_, err := session.GetInt64(-14, false, true)
+	if err == nil {
+		t.Fatal("expected error for negative size, got nil")
+	}
+}

--- a/v3/network/basic_session.go
+++ b/v3/network/basic_session.go
@@ -55,7 +55,7 @@ func (session *basicSession) GetInt64(size int, compress bool, bigEndian bool) (
 	}
 	if size == 0 {
 		return 0, nil
-	} else if size > 8 {
+	} else if size < 0 || size > 8 {
 		// When compress is true, "size" may be a value greater than 8 in some cases
 		return 0, errors.New("invalid size for GetInt64: " + strconv.Itoa(size))
 	}


### PR DESCRIPTION
## Fix for #714: panic: slice bounds out of range [-14] when switching RAC instances

### Problem
During Oracle RAC instance switchover, the network stream can become corrupted, causing `GetInt64` to receive a negative size value. The existing guard only checked `size > 8` but not `size < 0`, leading to:

```
panic: runtime error: slice bounds out of range [-14]
github.com/sijms/go-ora/v2/network.(*Session).GetInt64
```

### Root Cause
``go
// BEFORE — only checks upper bound
if size == 0 {
    return 0, nil
} else if size > 8 {
    return 0, errors.New("invalid size for GetInt64: " + ...)
}
// size < 0 falls through to make([]byte, size) → panic
``

### Fix
Add `size < 0` to the guard condition:

``go
// AFTER — checks both bounds
if size == 0 {
    return 0, nil
} else if size < 0 || size > 8 {
    return 0, errors.New("invalid size for GetInt64: " + ...)
}
``

### Files Changed
- `v2/network/session.go` — add `size < 0` guard in `GetInt64()`
- `v3/network/basic_session.go` — same guard
- `v2/network/session_getint64_test.go` (new) — `TestGetInt64NegativeSize`

### Verification
- `v2`: `go build ./...` OK, `GOOS=linux GOARCH=386 go build ./...` OK
- `v2`: `go test -run TestGetInt64NegativeSize ./network/` passes
- `v3`: `go build ./...` OK

Closes #714